### PR TITLE
TRT-611: Add GitHub CI/CD

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Description
+
+A short description of the changes in this PR.
+
+## Jira Issue ID
+
+
+## Local Test Steps
+
+
+## PR Acceptance Checklist
+
+* [ ] Jira ticket acceptance criteria met.
+* [ ] `CHANGELOG.md` updated to include high level summary of PR changes.
+* [ ] `docker/service_version.txt` updated if publishing a release.
+* [ ] Tests added/updated and passing.
+* [ ] Documentation updated (if needed).

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -1,0 +1,83 @@
+# This workflow will run when changes are detected in the `main` branch, which
+# must include an update to the `docker/service_version.txt` file. The workflow
+# can also be manually triggered by a repository maintainer. This workflow will
+# first trigger the reusable workflow in `.github/workflows/run_tests.yml`,
+# which runs the `unittest` suite. If that workflow is successful, the latest
+# version of the service Docker image is pushed to ghcr.io, a tag is added to
+# the latest git commit, and a GitHub release is created with the release notes
+# from the latest version of the Harmony Metadata Annotator.
+name: Publish Harmony Metadata Annotator Docker image
+
+on:
+  push:
+    branches: [ main ]
+    paths: docker/service_version.txt
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: ${{ github.repository }}
+  REGISTRY: ghcr.io
+
+jobs:
+  run_tests:
+    uses: ./.github/workflows/run_tests.yml
+
+  build_and_publish_image:
+    needs: run_tests
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      # write permission is required to create a GitHub release
+      contents: write
+      id-token: write
+      packages: write
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: Checkout harmony-metadata-annotator repository
+        uses: actions/checkout@v3
+        with:
+          lfs: true
+
+      - name: Extract semantic version number
+        run: echo "semantic_version=$(cat docker/service_version.txt)" >> $GITHUB_ENV
+
+      - name: Extract release version notes
+        run: |
+          version_release_notes=$(./bin/extract-release-notes.sh)
+          echo "RELEASE_NOTES<<EOF" >> $GITHUB_ENV
+          echo "${version_release_notes}" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: Log-in to ghcr.io registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Add tags to the Docker image
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ env.semantic_version }}
+
+      - name: Push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: docker/service.Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Publish GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          body: ${{ env.RELEASE_NOTES }}
+          commit: main
+          name: Version ${{ env.semantic_version }}
+          tag: ${{ env.semantic_version }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -29,14 +29,8 @@ jobs:
       - name: Run test image
         run: ./bin/run-test
 
-      - name: Archive test results
+      - name: Archive test results and coverage
         uses: actions/upload-artifact@v4
         with:
-          name: Test results
-          path: test-reports/
-
-      - name: Archive coverage report
-        uses: actions/upload-artifact@v4
-        with:
-          name: Coverage report
-          path: coverage/*
+          name: reports
+          path: reports/**/*

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,0 +1,42 @@
+# This workflow will build the service and test Docker images for the Harmony
+# Metadata Annotator, then run the Python `unittest` suite within a test Docker
+# container, reporting test results and code coverage as artefacts. It will be
+# called by the workflow that run tests against new PRs and as a first step in
+# the workflow that publishes new Docker images.
+name: Run Python unit tests
+
+on:
+  workflow_call
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: Checkout harmony-metadata-annotator repository
+        uses: actions/checkout@v3
+        with:
+          lfs: true
+
+      - name: Build service image
+        run: ./bin/build-image
+
+      - name: Build test image
+        run: ./bin/build-test
+
+      - name: Run test image
+        run: ./bin/run-test
+
+      - name: Archive test results
+        uses: actions/upload-artifact@v4
+        with:
+          name: Test results
+          path: test-reports/
+
+      - name: Archive coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: Coverage report
+          path: coverage/*

--- a/.github/workflows/run_tests_on_pull_requests.yml
+++ b/.github/workflows/run_tests_on_pull_requests.yml
@@ -1,0 +1,13 @@
+# This workflow will run when a PR is opened against the `main` branch. It will
+# trigger the reusable workflow in `.github/workflows/run_tests.yml`, which
+# builds the service and test Docker images, and runs the unit test suite in a
+# Docker container built from the test image.
+name: Run Python unit tests for pull requests against main
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build_and_test:
+    uses: ./.github/workflows/run_tests.yml

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,5 @@
+
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.0
+language-settings:
+  python: "3.12"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.0.0] - 2025-03-28
+
+- This is the first formal release of the Harmony Metadata Annotator as
+  as Docker image available through the GitHub Container Registry.
+- Service functionality: Ability to create, update, delete metadata attributes
+  for a variable as specified via an `earthdata-varinfo` configuration file.
+
 ## [v0.0.1] - 2025-02-20
 
 ### Added
 
 - Initial repository setup with utility scripts and Dockerfiles.
 
+[v1.0.0]: https://github.com/nasa/harmony-metadata-annotator/releases/tag/1.0.0
 [v0.0.1]: https://github.com/nasa/harmony-metadata-annotator/releases/tag/0.0.1

--- a/bin/run-test
+++ b/bin/run-test
@@ -20,6 +20,6 @@ mkdir -p reports/coverage
 # Run the tests in a Docker container with mounted volumes for XML report
 # output and test coverage reporting
 docker run --platform linux/amd64 --rm \
-	-v $(pwd)/reports/test-reports:/home/tests/reports \
-	-v $(pwd)/reports/coverage:/home/tests/coverage \
+	-v $(pwd)/reports/test-reports:/home/reports/test-reports \
+	-v $(pwd)/reports/coverage:/home/reports/coverage \
 	ghcr.io/nasa/harmony-metadata-annotator-test "$@"

--- a/bin/run-test
+++ b/bin/run-test
@@ -12,14 +12,14 @@ set -ex
 find . | grep -E "(__pycache__|\.pyc|\.pyo$)" | xargs rm -rf
 
 # Make the directory into which XML format test reports will be saved
-mkdir -p test-reports
+mkdir -p reports/test-reports
 
 # Make the directory into which coverage reports will be saved
-mkdir -p coverage
+mkdir -p reports/coverage
 
 # Run the tests in a Docker container with mounted volumes for XML report
 # output and test coverage reporting
 docker run --platform linux/amd64 --rm \
-	-v $(pwd)/test-reports:/home/tests/reports \
-	-v $(pwd)/coverage:/home/tests/coverage \
+	-v $(pwd)/reports/test-reports:/home/tests/reports \
+	-v $(pwd)/reports/coverage:/home/tests/coverage \
 	ghcr.io/nasa/harmony-metadata-annotator-test "$@"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Module to enable discoverability of tests."""

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+"""Module to enable discoverability of tests."""


### PR DESCRIPTION
## Description

This PR adds the GitHub workflows similar to those used in other DAS Harmony services:

* `run_tests.yml` - this is the core workflow that executes the unit test suite. It is called for PRs, and also prior to releasing a new version of the service.
* `run_tests_on_pull_requests.yml` - this executes the `run_tests.yml` workflow when a PR is opened or updated.
* `publish_docker_image.yml` - this first executes the `run_tests.yml` workflow and then, if the tests pass, publishes a new Docker image to the GitHub Container registry. It will do this when a new commit gets to `main`, and the changes include a change to `docker/service_version.txt`.

I've update the `service_version.txt` and `CHANGELOG.md` in order to trigger an initial release to the GitHub container registry.

## Jira Issue ID

TRT-611

## Local Test Steps

* N/A - mainly make sure I've updated the workflows to not refer to other repositories.

## PR Acceptance Checklist

* ~~Jira ticket acceptance criteria met.~~
* [x] `CHANGELOG.md` updated to include high level summary of PR changes.
* [x] `docker/service_version.txt` updated if publishing a release.
* ~~Tests added/updated and passing.~~
* [x] Documentation updated (if needed).