### PR TITLE
DAS-2297 - Update SMAP L3 varinfo config to add geotransform and missing dimensions

### DIFF
--- a/.github/workflows/run_tests_on_pull_requests.yml
+++ b/.github/workflows/run_tests_on_pull_requests.yml
@@ -6,7 +6,7 @@ name: Run Python unit tests for pull requests against main
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, '*feature*' ]
 
 jobs:
   build_and_test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased] - 2025-04-22
+
+### Changed
+
+- The earthdata varinfo configuration file was updated for SMAP L3 collections to make the global grid mapping variables resolution specific, add a `master_geotransform` attribute to all grid mapping variables, add missing dimension variables, and create a dimensions attribute on their associated variables.
+
 ## [v1.0.0] - 2025-03-28
 
 - This is the first formal release of the Harmony Metadata Annotator as

--- a/README.md
+++ b/README.md
@@ -150,8 +150,8 @@ http://localhost:3000/C1246896616-EEDTEST/ogc-api-coverages/1.0.0/collections/al
 
 To see that this request worked download the output (using `localhost:3000/jobs`
 to find the results URL). Then open that file in Panoply. First note the new CRS
-variables in the root group of the output: `/EASE2_global_projection` and
-`/EASE2_polar_projection_9km`. These were defined in the
+variables in the root group of the output: `/EASE2_global_projection_36km` and
+`/EASE2_north_polar_projection_36km`. These were defined in the
 `earthdata_varinfo_config.json` file. Next look at one of the variables, e.g.:
 `/Soil_Moisture_Retrieval_Data_AM/albedo`. This will now have a `grid_mapping`
 metadata attribute, which was absent in the native data.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ regarding creation of a local Harmony instance.
 For local development and testing of library modifications or small functions independent of the main Harmony application:
 
 1. Create a Python virtual environment
-1. Install the dependencies in `pip_requirements.txt`, and `tests/pip_test_requirements.txt`
+1. Install the dependencies in `requirements.txt`, and `tests/test_requirements.txt`
 1. Install the pre-commit hooks ([described below](#pre-commit-hooks)).
 
 ## Enabling the service in Harmony in a Box:

--- a/metadata_annotator/earthdata_varinfo_config.json
+++ b/metadata_annotator/earthdata_varinfo_config.json
@@ -76,13 +76,13 @@
     {
       "Applicability": {
         "Mission": "SMAP",
-        "ShortNamePath": "SPL3FT(P|P_E)",
-        "VariablePattern": "(?i).*global.*"
+        "ShortNamePath": "SPL3FTP$",
+        "VariablePattern": "/Freeze_Thaw_Retrieval_Data_Global/(?!am_pm$).+$"
       },
       "Attributes": [
         {
           "Name": "grid_mapping",
-          "Value": "/EASE2_global_projection"
+          "Value": "/EASE2_global_projection_36km"
         }
       ],
       "_Description": "SMAP L3 collections omit global grid mapping information"
@@ -90,8 +90,8 @@
     {
       "Applicability": {
         "Mission": "SMAP",
-        "ShortNamePath": "SPL3FTP",
-        "VariablePattern": "/Freeze_Thaw_Retrieval_Data_Polar/.*"
+        "ShortNamePath": "SPL3FTP$",
+        "VariablePattern": "/Freeze_Thaw_Retrieval_Data_Polar/(?!am_pm$).+$"
       },
       "Attributes": [
         {
@@ -105,7 +105,21 @@
       "Applicability": {
         "Mission": "SMAP",
         "ShortNamePath": "SPL3FTP_E",
-        "VariablePattern": "/Freeze_Thaw_Retrieval_Data_Polar/.*"
+        "VariablePattern": "/Freeze_Thaw_Retrieval_Data_Global/(?!am_pm$).+$"
+      },
+      "Attributes": [
+        {
+          "Name": "grid_mapping",
+          "Value": "/EASE2_global_projection_9km"
+        }
+      ],
+      "_Description": "SMAP L3 collections omit global grid mapping information"
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3FTP_E",
+        "VariablePattern": "/Freeze_Thaw_Retrieval_Data_Polar/(?!am_pm$).+$"
       },
       "Attributes": [
         {
@@ -124,7 +138,7 @@
       "Attributes": [
         {
           "Name": "grid_mapping",
-          "Value": "/EASE2_global_projection"
+          "Value": "/EASE2_global_projection_9km"
         }
       ],
       "_Description": "SMAP L3 collections omit global grid mapping information"
@@ -146,7 +160,8 @@
     {
       "Applicability": {
         "Mission": "SMAP",
-        "ShortNamePath": "SPL3FTA"
+        "ShortNamePath": "SPL3FTA",
+        "VariablePattern": "/(Freeze_Thaw_Retrieval_Data|Radar_Data|Ancillary_Data)/(?!am_pm$).+$"
       },
       "Attributes": [
         {
@@ -159,12 +174,13 @@
     {
       "Applicability": {
         "Mission": "SMAP",
-        "ShortNamePath": "SPL3SM(P|A|AP)$|SPL2SMAP_S"
+        "ShortNamePath": "SPL2SMAP_S",
+        "VariablePattern": "/Soil_Moisture_Retrieval_Data_1km/.*"
       },
       "Attributes": [
         {
           "Name": "grid_mapping",
-          "Value": "/EASE2_global_projection"
+          "Value": "/EASE2_global_projection_1km"
         }
       ],
       "_Description": "SMAP L3 collections omit global grid mapping information"
@@ -172,8 +188,64 @@
     {
       "Applicability": {
         "Mission": "SMAP",
-        "ShortNamePath": "SPL3FT(P|P_E)|SPL3SM(P|P_E|A|AP)|SPL2SMAP_S",
-        "VariablePattern": "/EASE2_global_projection"
+        "ShortNamePath": "SPL2SMAP_S",
+        "VariablePattern": "/Soil_Moisture_Retrieval_Data_3km/.*"
+      },
+      "Attributes": [
+        {
+          "Name": "grid_mapping",
+          "Value": "/EASE2_global_projection_3km"
+        }
+      ],
+      "_Description": "SMAP L3 collections omit global grid mapping information"
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3SMA$",
+        "VariablePattern": "/(Soil_Moisture_Retrieval_Data|Radar_Data|Ancillary_Data)/.*"
+      },
+      "Attributes": [
+        {
+          "Name": "grid_mapping",
+          "Value": "/EASE2_global_projection_3km"
+        }
+      ],
+      "_Description": "SMAP L3 collections omit global grid mapping information"
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3SMAP",
+        "VariablePattern": "/Soil_Moisture_Retrieval_Data/.*"
+      },
+      "Attributes": [
+        {
+          "Name": "grid_mapping",
+          "Value": "/EASE2_global_projection_9km"
+        }
+      ],
+      "_Description": "SMAP L3 collections omit global grid mapping information"
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3SMP$",
+        "VariablePattern": "/Soil_Moisture_Retrieval_Data_(AM|PM)/(?!lc_type$).+$"
+      },
+      "Attributes": [
+        {
+          "Name": "grid_mapping",
+          "Value": "/EASE2_global_projection_36km"
+        }
+      ],
+      "_Description": "SMAP L3 collections omit global grid mapping information"
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL2SMAP_S",
+        "VariablePattern": "/EASE2_global_projection_1km"
       },
       "Attributes": [
         {
@@ -195,6 +267,112 @@
         {
           "Name": "false_northing",
           "Value": 0.0
+        },
+        {
+          "Name": "master_geotransform",
+          "Value": [-17367530.4451615, 1001.0104, 0, 7314540.8306386, 0, -1001.0104]
+        }
+      ],
+      "_Description": "Provide missing global grid mapping attributes for SMAP L3 collections."
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3SMA$|SPL2SMAP_S",
+        "VariablePattern": "/EASE2_global_projection_3km"
+      },
+      "Attributes": [
+        {
+          "Name": "grid_mapping_name",
+          "Value": "lambert_cylindrical_equal_area"
+        },
+        {
+          "Name": "standard_parallel",
+          "Value": 30.0
+        },
+        {
+          "Name": "longitude_of_central_meridian",
+          "Value": 0.0
+        },
+        {
+          "Name": "false_easting",
+          "Value": 0.0
+        },
+        {
+          "Name": "false_northing",
+          "Value": 0.0
+        },
+        {
+          "Name": "master_geotransform",
+          "Value": [-17367530.4451615, 3003.0312, 0, 7314540.8306386, 0, -3003.0312]
+        }
+      ],
+      "_Description": "Provide missing global grid mapping attributes for SMAP L3 collections."
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3FTP_E|SPL3SMAP|SPL3SMP_E",
+        "VariablePattern": "/EASE2_global_projection_9km"
+      },
+      "Attributes": [
+        {
+          "Name": "grid_mapping_name",
+          "Value": "lambert_cylindrical_equal_area"
+        },
+        {
+          "Name": "standard_parallel",
+          "Value": 30.0
+        },
+        {
+          "Name": "longitude_of_central_meridian",
+          "Value": 0.0
+        },
+        {
+          "Name": "false_easting",
+          "Value": 0.0
+        },
+        {
+          "Name": "false_northing",
+          "Value": 0.0
+        },
+        {
+          "Name": "master_geotransform",
+          "Value": [-17367530.4451615, 9009.0936, 0, 7314540.8306386, 0, -9009.0936]
+        }
+      ],
+      "_Description": "Provide missing global grid mapping attributes for SMAP L3 collections."
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3FTP$|SPL3SMP$",
+        "VariablePattern": "/EASE2_global_projection_36km"
+      },
+      "Attributes": [
+        {
+          "Name": "grid_mapping_name",
+          "Value": "lambert_cylindrical_equal_area"
+        },
+        {
+          "Name": "standard_parallel",
+          "Value": 30.0
+        },
+        {
+          "Name": "longitude_of_central_meridian",
+          "Value": 0.0
+        },
+        {
+          "Name": "false_easting",
+          "Value": 0.0
+        },
+        {
+          "Name": "false_northing",
+          "Value": 0.0
+        },
+        {
+          "Name": "master_geotransform",
+          "Value": [-17367530.44, 36036.3744, 0, 7314540.83, 0, -36036.3744]
         }
       ],
       "_Description": "Provide missing global grid mapping attributes for SMAP L3 collections."
@@ -225,6 +403,10 @@
         {
           "Name": "false_northing",
           "Value": 0.0
+        },
+        {
+          "Name": "master_geotransform",
+          "Value": [-9000000, 3000, 0, 9000000, 0, -3000]
         }
       ],
       "_Description": "Provide missing polar grid mapping attributes for SMAP L3 collections."
@@ -255,6 +437,10 @@
         {
           "Name": "false_northing",
           "Value": 0.0
+        },
+        {
+          "Name": "master_geotransform",
+          "Value": [-9000000, 9000, 0, 9000000, 0, -9000]
         }
       ],
       "_Description": "Provide missing polar grid mapping attributes for SMAP L3 collections."
@@ -262,7 +448,7 @@
     {
       "Applicability": {
         "Mission": "SMAP",
-        "ShortNamePath": "SPL3FTP",
+        "ShortNamePath": "SPL3FTP$",
         "VariablePattern": "/EASE2_polar_projection_36km"
       },
       "Attributes": [
@@ -285,6 +471,10 @@
         {
           "Name": "false_northing",
           "Value": 0.0
+        },
+        {
+          "Name": "master_geotransform",
+          "Value": [-9000000, 36000, 0, 9000000, 0, -36000]
         }
       ],
       "_Description": "Provide missing polar grid mapping attributes for SMAP L3 collections."

--- a/metadata_annotator/earthdata_varinfo_config.json
+++ b/metadata_annotator/earthdata_varinfo_config.json
@@ -553,6 +553,10 @@
         {
           "Name": "units",
           "Value": "m"
+        },
+        {
+          "Name": "type",
+          "Value": "float64"
         }
       ],
       "_Description": "The pseudo-dimension variable is supplemented with variable attributes (as if it was a dimension variables) to fully specify the X dimension."
@@ -575,6 +579,10 @@
         {
           "Name": "units",
           "Value": "m"
+        },
+        {
+          "Name": "type",
+          "Value": "float64"
         }
       ],
       "_Description": "The pseudo-dimension variable is supplemented with variable attributes (as if it was a dimension variables) to fully specify the Y dimension."
@@ -601,6 +609,10 @@
         {
           "Name": "units",
           "Value": "m"
+        },
+        {
+          "Name": "type",
+          "Value": "float64"
         }
       ],
       "_Description": "The pseudo-dimension variable is supplemented with variable attributes (as if it was a dimension variables) to fully specify the X dimension."
@@ -627,6 +639,10 @@
         {
           "Name": "units",
           "Value": "m"
+        },
+        {
+          "Name": "type",
+          "Value": "float64"
         }
       ],
       "_Description": "The pseudo-dimension variable is supplemented with variable attributes (as if it was a dimension variables) to fully specify the Y dimension."
@@ -653,6 +669,10 @@
         {
           "Name": "units",
           "Value": "m"
+        },
+        {
+          "Name": "type",
+          "Value": "float64"
         }
       ],
       "_Description": "The pseudo-dimension variable is supplemented with variable attributes (as if it was a dimension variables) to fully specify the X dimension."
@@ -679,6 +699,10 @@
         {
           "Name": "units",
           "Value": "m"
+        },
+        {
+          "Name": "type",
+          "Value": "float64"
         }
       ],
       "_Description": "The pseudo-dimension variable is supplemented with variable attributes (as if it was a dimension variables) to fully specify the Y dimension."
@@ -705,6 +729,10 @@
         {
           "Name": "units",
           "Value": "m"
+        },
+        {
+          "Name": "type",
+          "Value": "float64"
         }
       ],
       "_Description": "The pseudo-dimension variable is supplemented with variable attributes (as if it was a dimension variables) to fully specify the X dimension."
@@ -731,6 +759,10 @@
         {
           "Name": "units",
           "Value": "m"
+        },
+        {
+          "Name": "type",
+          "Value": "float64"
         }
       ],
       "_Description": "The pseudo-dimension variable is supplemented with variable attributes (as if it was a dimension variables) to fully specify the Y dimension."
@@ -749,6 +781,10 @@
         {
           "Name": "long_name",
           "Value": "land cover type"
+        },
+        {
+          "Name": "type",
+          "Value": "uint8"
         }
       ],
       "_Description": "The pseudo-dimension variable is supplemented with variable attributes (as if it was a dimension variable) to clarify the dimension name"
@@ -775,6 +811,10 @@
         {
           "Name": "units",
           "Value": "m"
+        },
+        {
+          "Name": "type",
+          "Value": "float64"
         }
       ],
       "_Description": "The pseudo-dimension variable is supplemented with variable attributes (as if it was a dimension variables) to fully specify the X dimension."
@@ -801,6 +841,10 @@
         {
           "Name": "units",
           "Value": "m"
+        },
+        {
+          "Name": "type",
+          "Value": "float64"
         }
       ],
       "_Description": "The pseudo-dimension variable is supplemented with variable attributes (as if it was a dimension variables) to fully specify the Y dimension."
@@ -819,6 +863,10 @@
         {
           "Name": "long_name",
           "Value": "land cover type"
+        },
+        {
+          "Name": "type",
+          "Value": "uint8"
         }
       ],
       "_Description": "The pseudo-dimension variable is supplemented with variable attributes (as if it was a dimension variable) to clarify the dimension name"
@@ -845,6 +893,10 @@
         {
           "Name": "units",
           "Value": "m"
+        },
+        {
+          "Name": "type",
+          "Value": "float64"
         }
       ],
       "_Description": "The pseudo-dimension variable is supplemented with variable attributes (as if it was a dimension variables) to fully specify the X dimension."
@@ -871,6 +923,10 @@
         {
           "Name": "units",
           "Value": "m"
+        },
+        {
+          "Name": "type",
+          "Value": "float64"
         }
       ],
       "_Description": "The pseudo-dimension variable is supplemented with variable attributes (as if it was a dimension variables) to fully specify the Y dimension."
@@ -897,6 +953,10 @@
         {
           "Name": "units",
           "Value": "m"
+        },
+        {
+          "Name": "type",
+          "Value": "float64"
         }
       ],
       "_Description": "The pseudo-dimension variable is supplemented with variable attributes (as if it was a dimension variables) to fully specify the X dimension."
@@ -923,6 +983,10 @@
         {
           "Name": "units",
           "Value": "m"
+        },
+        {
+          "Name": "type",
+          "Value": "float64"
         }
       ],
       "_Description": "The pseudo-dimension variable is supplemented with variable attributes (as if it was a dimension variables) to fully specify the Y dimension."
@@ -949,6 +1013,10 @@
         {
           "Name": "units",
           "Value": "m"
+        },
+        {
+          "Name": "type",
+          "Value": "float64"
         }
       ],
       "_Description": "The pseudo-dimension variable is here supplemented with variable attributes (as if it was a dimension variables) to fully specify the X dimension."
@@ -975,6 +1043,10 @@
         {
           "Name": "units",
           "Value": "m"
+        },
+        {
+          "Name": "type",
+          "Value": "float64"
         }
       ],
       "_Description": "The pseudo-dimension variable is here supplemented with variable attributes (as if it was a dimension variables) to fully specify the Y dimension."
@@ -993,6 +1065,10 @@
         {
           "Name": "long_name",
           "Value": "AM-PM dimension of size 2, 0 => AM, 1=> PM"
+        },
+        {
+          "Name": "type",
+          "Value": "uint8"
         }
       ],
       "_Description": "The pseudo-dimension variable is here supplemented with variable attributes (as if it was a dimension variables) to clarify the dimension name"
@@ -1019,6 +1095,10 @@
         {
           "Name": "units",
           "Value": "m"
+        },
+        {
+          "Name": "type",
+          "Value": "float64"
         }
       ],
       "_Description": "The pseudo-dimension variable is here supplemented with variable attributes (as if it was a dimension variables) to fully specify the X dimension."
@@ -1045,6 +1125,10 @@
         {
           "Name": "units",
           "Value": "m"
+        },
+        {
+          "Name": "type",
+          "Value": "float64"
         }
       ],
       "_Description": "The pseudo-dimension variable is here supplemented with variable attributes (as if it was a dimension variables) to fully specify the Y dimension."
@@ -1063,9 +1147,13 @@
         {
           "Name": "long_name",
           "Value": "AM-PM dimension of size 2, 0 => AM, 1=> PM"
+        },
+        {
+          "Name": "type",
+          "Value": "uint8"
         }
       ],
-      "_Description": ""
+      "_Description": "The pseudo-dimension variable is here supplemented with variable attributes (as if it was a dimension variables) to clarify the dimension name"
     },
     {
       "Applicability": {
@@ -1089,6 +1177,10 @@
         {
           "Name": "units",
           "Value": "m"
+        },
+        {
+          "Name": "type",
+          "Value": "float64"
         }
       ],
       "_Description": "The pseudo-dimension variable is here supplemented with variable attributes (as if it was a dimension variables) to fully specify the X dimension."
@@ -1115,6 +1207,10 @@
         {
           "Name": "units",
           "Value": "m"
+        },
+        {
+          "Name": "type",
+          "Value": "float64"
         }
       ],
       "_Description": "The pseudo-dimension variable is here supplemented with variable attributes (as if it was a dimension variables) to fully specify the Y dimension."
@@ -1133,6 +1229,10 @@
         {
           "Name": "long_name",
           "Value": "AM-PM dimension of size 2, 0 => AM, 1=> PM"
+        },
+        {
+          "Name": "type",
+          "Value": "uint8"
         }
       ],
       "_Description": "SMAP L3 data are HDF5 and without dimension settings. Overrides here define the dimensions, a useful reference name, and critically, the dimension order."

--- a/metadata_annotator/earthdata_varinfo_config.json
+++ b/metadata_annotator/earthdata_varinfo_config.json
@@ -161,7 +161,7 @@
       "Applicability": {
         "Mission": "SMAP",
         "ShortNamePath": "SPL3FTA",
-        "VariablePattern": "/(Freeze_Thaw_Retrieval_Data|Radar_Data|Ancillary_Data)/(?!am_pm$).+$"
+        "VariablePattern": "/(Freeze_Thaw_Retrieval_Data|Radar_Data|Ancillary_Data)/.*|/(x|y)"
       },
       "Attributes": [
         {
@@ -203,7 +203,7 @@
       "Applicability": {
         "Mission": "SMAP",
         "ShortNamePath": "SPL3SMA$",
-        "VariablePattern": "/(Soil_Moisture_Retrieval_Data|Radar_Data|Ancillary_Data)/.*"
+        "VariablePattern": "/(Soil_Moisture_Retrieval_Data|Radar_Data|Ancillary_Data)/.*|/(x|y)"
       },
       "Attributes": [
         {
@@ -634,7 +634,7 @@
     {
       "Applicability": {
         "Mission": "SMAP",
-        "ShortNamePath": "SPL3SM(A|AP)",
+        "ShortNamePath": "SPL3SMAP",
         "VariablePattern": "/Soil_Moisture_Retrieval_Data/x"
       },
       "Attributes": [
@@ -660,7 +660,7 @@
     {
       "Applicability": {
         "Mission": "SMAP",
-        "ShortNamePath": "SPL3SM(A|AP)",
+        "ShortNamePath": "SPL3SMAP",
         "VariablePattern": "/Soil_Moisture_Retrieval_Data/y"
       },
       "Attributes": [
@@ -930,8 +930,8 @@
     {
       "Applicability": {
         "Mission": "SMAP",
-        "ShortNamePath": "SPL3FTA",
-        "VariablePattern": "/Freeze_Thaw_Retrieval_Data/x"
+        "ShortNamePath": "SPL3FTA|SPL3SMA$",
+        "VariablePattern": "/x"
       },
       "Attributes": [
         {
@@ -956,8 +956,8 @@
     {
       "Applicability": {
         "Mission": "SMAP",
-        "ShortNamePath": "SPL3FTA",
-        "VariablePattern": "/Freeze_Thaw_Retrieval_Data/y"
+        "ShortNamePath": "SPL3FTA|SPL3SMA$",
+        "VariablePattern": "/y"
       },
       "Attributes": [
         {
@@ -983,7 +983,7 @@
       "Applicability": {
         "Mission": "SMAP",
         "ShortNamePath": "SPL3FTA",
-        "VariablePattern": "/Freeze_Thaw_Retrieval_Data/am_pm"
+        "VariablePattern": "/am_pm"
       },
       "Attributes": [
         {
@@ -1155,7 +1155,7 @@
       "Applicability": {
         "Mission": "SMAP",
         "ShortNamePath": "SPL3SMA$",
-        "VariablePattern": "/Soil_Moisture_Retrieval_Data/(?!x$|y$).+$|/(Radar_Data|Ancillary_Data)/.*"
+        "VariablePattern": "/(Soil_Moisture_Retrieval_Data|Radar_Data|Ancillary_Data)/.*"
       },
       "Attributes": [
         {
@@ -1211,7 +1211,7 @@
       "Applicability": {
         "Mission": "SMAP",
         "ShortNamePath": "SPL3FTA",
-        "VariablePattern": "/Freeze_Thaw_Retrieval_Data/(?!transition_state_flag$|transition_direction$|am_pm$|x$|y$).+$|/(Radar_Data|Ancillary_Data)/.*"
+        "VariablePattern": "/Freeze_Thaw_Retrieval_Data/(?!transition_state_flag$|transition_direction$).+$|/(Radar_Data|Ancillary_Data)/.*"
       },
       "Attributes": [
         {

--- a/metadata_annotator/earthdata_varinfo_config.json
+++ b/metadata_annotator/earthdata_varinfo_config.json
@@ -270,7 +270,7 @@
         },
         {
           "Name": "master_geotransform",
-          "Value": [-17367530.4451615, 1001.0104, 0, 7314540.8306386, 0, -1001.0104]
+          "Value": [-17367530.4451615, 1000.89502335, 0, 7314540.8306386, 0, -1000.89502335]
         }
       ],
       "_Description": "Provide missing global grid mapping attributes for SMAP L3 collections."
@@ -304,7 +304,7 @@
         },
         {
           "Name": "master_geotransform",
-          "Value": [-17367530.4451615, 3003.0312, 0, 7314540.8306386, 0, -3003.0312]
+          "Value": [-17367530.4451615, 3002.6850700487, 0, 7314540.8306386, 0, -3002.6850700487]
         }
       ],
       "_Description": "Provide missing global grid mapping attributes for SMAP L3 collections."
@@ -338,7 +338,7 @@
         },
         {
           "Name": "master_geotransform",
-          "Value": [-17367530.4451615, 9009.0936, 0, 7314540.8306386, 0, -9009.0936]
+          "Value": [-17367530.4451615, 9008.055210146, 0, 7314540.8306386, 0, -9008.055210146]
         }
       ],
       "_Description": "Provide missing global grid mapping attributes for SMAP L3 collections."
@@ -372,7 +372,7 @@
         },
         {
           "Name": "master_geotransform",
-          "Value": [-17367530.44, 36036.3744, 0, 7314540.83, 0, -36036.3744]
+          "Value": [-17367530.44, 36032.22084058, 0, 7314540.83, 0, -36032.22084058]
         }
       ],
       "_Description": "Provide missing global grid mapping attributes for SMAP L3 collections."

--- a/metadata_annotator/earthdata_varinfo_config.json
+++ b/metadata_annotator/earthdata_varinfo_config.json
@@ -547,8 +547,16 @@
           "Value": "projection_x_coordinate"
         },
         {
+          "Name": "long_name",
+          "Value": "x coordinate of projection"
+        },
+        {
           "Name": "dimensions",
           "Value": "x"
+        },
+        {
+          "Name": "axis",
+          "Value": "X"
         },
         {
           "Name": "units",
@@ -573,8 +581,16 @@
           "Value": "projection_y_coordinate"
         },
         {
+          "Name": "long_name",
+          "Value": "y coordinate of projection"
+        },
+        {
           "Name": "dimensions",
           "Value": "y"
+        },
+        {
+          "Name": "axis",
+          "Value": "Y"
         },
         {
           "Name": "units",
@@ -607,6 +623,10 @@
           "Value": "x"
         },
         {
+          "Name": "axis",
+          "Value": "X"
+        },
+        {
           "Name": "units",
           "Value": "m"
         },
@@ -635,6 +655,10 @@
         {
           "Name": "dimensions",
           "Value": "y"
+        },
+        {
+          "Name": "axis",
+          "Value": "Y"
         },
         {
           "Name": "units",
@@ -667,6 +691,10 @@
           "Value": "x"
         },
         {
+          "Name": "axis",
+          "Value": "X"
+        },
+        {
           "Name": "units",
           "Value": "m"
         },
@@ -695,6 +723,10 @@
         {
           "Name": "dimensions",
           "Value": "y"
+        },
+        {
+          "Name": "axis",
+          "Value": "Y"
         },
         {
           "Name": "units",
@@ -727,6 +759,10 @@
           "Value": "x"
         },
         {
+          "Name": "axis",
+          "Value": "X"
+        },
+        {
           "Name": "units",
           "Value": "m"
         },
@@ -755,6 +791,10 @@
         {
           "Name": "dimensions",
           "Value": "y"
+        },
+        {
+          "Name": "axis",
+          "Value": "Y"
         },
         {
           "Name": "units",
@@ -809,6 +849,10 @@
           "Value": "x"
         },
         {
+          "Name": "axis",
+          "Value": "X"
+        },
+        {
           "Name": "units",
           "Value": "m"
         },
@@ -837,6 +881,10 @@
         {
           "Name": "dimensions",
           "Value": "y"
+        },
+        {
+          "Name": "axis",
+          "Value": "Y"
         },
         {
           "Name": "units",
@@ -891,6 +939,10 @@
           "Value": "x"
         },
         {
+          "Name": "axis",
+          "Value": "X"
+        },
+        {
           "Name": "units",
           "Value": "m"
         },
@@ -919,6 +971,10 @@
         {
           "Name": "dimensions",
           "Value": "y"
+        },
+        {
+          "Name": "axis",
+          "Value": "Y"
         },
         {
           "Name": "units",
@@ -951,6 +1007,10 @@
           "Value": "x"
         },
         {
+          "Name": "axis",
+          "Value": "X"
+        },
+        {
           "Name": "units",
           "Value": "m"
         },
@@ -979,6 +1039,10 @@
         {
           "Name": "dimensions",
           "Value": "y"
+        },
+        {
+          "Name": "axis",
+          "Value": "Y"
         },
         {
           "Name": "units",
@@ -1011,6 +1075,10 @@
           "Value": "x"
         },
         {
+          "Name": "axis",
+          "Value": "X"
+        },
+        {
           "Name": "units",
           "Value": "m"
         },
@@ -1039,6 +1107,10 @@
         {
           "Name": "dimensions",
           "Value": "y"
+        },
+        {
+          "Name": "axis",
+          "Value": "Y"
         },
         {
           "Name": "units",
@@ -1093,6 +1165,10 @@
           "Value": "x"
         },
         {
+          "Name": "axis",
+          "Value": "X"
+        },
+        {
           "Name": "units",
           "Value": "m"
         },
@@ -1121,6 +1197,10 @@
         {
           "Name": "dimensions",
           "Value": "y"
+        },
+        {
+          "Name": "axis",
+          "Value": "Y"
         },
         {
           "Name": "units",
@@ -1175,6 +1255,10 @@
           "Value": "x"
         },
         {
+          "Name": "axis",
+          "Value": "X"
+        },
+        {
           "Name": "units",
           "Value": "m"
         },
@@ -1203,6 +1287,10 @@
         {
           "Name": "dimensions",
           "Value": "y"
+        },
+        {
+          "Name": "axis",
+          "Value": "Y"
         },
         {
           "Name": "units",

--- a/metadata_annotator/earthdata_varinfo_config.json
+++ b/metadata_annotator/earthdata_varinfo_config.json
@@ -96,7 +96,7 @@
       "Attributes": [
         {
           "Name": "grid_mapping",
-          "Value": "/EASE2_polar_projection_36km"
+          "Value": "/EASE2_north_polar_projection_36km"
         }
       ],
       "_Description": "SMAP L3 collections omit polar grid mapping information"
@@ -124,7 +124,7 @@
       "Attributes": [
         {
           "Name": "grid_mapping",
-          "Value": "/EASE2_polar_projection_9km"
+          "Value": "/EASE2_north_polar_projection_9km"
         }
       ],
       "_Description": "SMAP L3 collections omit polar grid mapping information"
@@ -152,7 +152,7 @@
       "Attributes": [
         {
           "Name": "grid_mapping",
-          "Value": "/EASE2_polar_projection_9km"
+          "Value": "/EASE2_north_polar_projection_9km"
         }
       ],
       "_Description": "SMAP L3 collections omit polar grid mapping information"
@@ -166,7 +166,7 @@
       "Attributes": [
         {
           "Name": "grid_mapping",
-          "Value": "/EASE2_polar_projection_3km"
+          "Value": "/EASE2_north_polar_projection_3km"
         }
       ],
       "_Description": "SMAP L3 collections omit polar grid mapping information"
@@ -381,7 +381,7 @@
       "Applicability": {
         "Mission": "SMAP",
         "ShortNamePath": "SPL3FTA",
-        "VariablePattern": "/EASE2_polar_projection_3km"
+        "VariablePattern": "/EASE2_north_polar_projection_3km"
       },
       "Attributes": [
         {
@@ -415,7 +415,7 @@
       "Applicability": {
         "Mission": "SMAP",
         "ShortNamePath": "SPL3FTP_E|SPL3SMP_E",
-        "VariablePattern": "/EASE2_polar_projection_9km"
+        "VariablePattern": "/EASE2_north_polar_projection_9km"
       },
       "Attributes": [
         {
@@ -449,7 +449,7 @@
       "Applicability": {
         "Mission": "SMAP",
         "ShortNamePath": "SPL3FTP$",
-        "VariablePattern": "/EASE2_polar_projection_36km"
+        "VariablePattern": "/EASE2_north_polar_projection_36km"
       },
       "Attributes": [
         {

--- a/metadata_annotator/earthdata_varinfo_config.json
+++ b/metadata_annotator/earthdata_varinfo_config.json
@@ -534,6 +534,706 @@
         }
       ],
       "_Description": "Ensure variables in /Soil_Moisture_Retrieval_Data_Polar_PM group point to correct coordinate variables."
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL2SMAP_S",
+        "VariablePattern": "/Soil_Moisture_Retrieval_Data_1km/x"
+      },
+      "Attributes": [
+        {
+          "Name": "standard_name",
+          "Value": "projection_x_coordinate"
+        },
+        {
+          "Name": "dimensions",
+          "Value": "x"
+        },
+        {
+          "Name": "units",
+          "Value": "m"
+        }
+      ],
+      "_Description": "The pseudo-dimension variable is supplemented with variable attributes (as if it was a dimension variables) to fully specify the X dimension."
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL2SMAP_S",
+        "VariablePattern": "/Soil_Moisture_Retrieval_Data_1km/y"
+      },
+      "Attributes": [
+        {
+          "Name": "standard_name",
+          "Value": "projection_y_coordinate"
+        },
+        {
+          "Name": "dimensions",
+          "Value": "y"
+        },
+        {
+          "Name": "units",
+          "Value": "m"
+        }
+      ],
+      "_Description": "The pseudo-dimension variable is supplemented with variable attributes (as if it was a dimension variables) to fully specify the Y dimension."
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL2SMAP_S",
+        "VariablePattern": "/Soil_Moisture_Retrieval_Data_3km/x"
+      },
+      "Attributes": [
+        {
+          "Name": "standard_name",
+          "Value": "projection_x_coordinate"
+        },
+        {
+          "Name": "long_name",
+          "Value": "x coordinate of projection"
+        },
+        {
+          "Name": "dimensions",
+          "Value": "x"
+        },
+        {
+          "Name": "units",
+          "Value": "m"
+        }
+      ],
+      "_Description": "The pseudo-dimension variable is supplemented with variable attributes (as if it was a dimension variables) to fully specify the X dimension."
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL2SMAP_S",
+        "VariablePattern": "/Soil_Moisture_Retrieval_Data_3km/y"
+      },
+      "Attributes": [
+        {
+          "Name": "standard_name",
+          "Value": "projection_y_coordinate"
+        },
+        {
+          "Name": "long_name",
+          "Value": "y coordinate of projection"
+        },
+        {
+          "Name": "dimensions",
+          "Value": "y"
+        },
+        {
+          "Name": "units",
+          "Value": "m"
+        }
+      ],
+      "_Description": "The pseudo-dimension variable is supplemented with variable attributes (as if it was a dimension variables) to fully specify the Y dimension."
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3SM(A|AP)",
+        "VariablePattern": "/Soil_Moisture_Retrieval_Data/x"
+      },
+      "Attributes": [
+        {
+          "Name": "standard_name",
+          "Value": "projection_x_coordinate"
+        },
+        {
+          "Name": "long_name",
+          "Value": "x coordinate of projection"
+        },
+        {
+          "Name": "dimensions",
+          "Value": "x"
+        },
+        {
+          "Name": "units",
+          "Value": "m"
+        }
+      ],
+      "_Description": "The pseudo-dimension variable is supplemented with variable attributes (as if it was a dimension variables) to fully specify the X dimension."
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3SM(A|AP)",
+        "VariablePattern": "/Soil_Moisture_Retrieval_Data/y"
+      },
+      "Attributes": [
+        {
+          "Name": "standard_name",
+          "Value": "projection_y_coordinate"
+        },
+        {
+          "Name": "long_name",
+          "Value": "y coordinate of projection"
+        },
+        {
+          "Name": "dimensions",
+          "Value": "y"
+        },
+        {
+          "Name": "units",
+          "Value": "m"
+        }
+      ],
+      "_Description": "The pseudo-dimension variable is supplemented with variable attributes (as if it was a dimension variables) to fully specify the Y dimension."
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3SM(P|P_E)",
+        "VariablePattern": "/Soil_Moisture_Retrieval_Data_AM/x"
+      },
+      "Attributes": [
+        {
+          "Name": "standard_name",
+          "Value": "projection_x_coordinate"
+        },
+        {
+          "Name": "long_name",
+          "Value": "x coordinate of projection"
+        },
+        {
+          "Name": "dimensions",
+          "Value": "x"
+        },
+        {
+          "Name": "units",
+          "Value": "m"
+        }
+      ],
+      "_Description": "The pseudo-dimension variable is supplemented with variable attributes (as if it was a dimension variables) to fully specify the X dimension."
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3SM(P|P_E)",
+        "VariablePattern": "/Soil_Moisture_Retrieval_Data_AM/y"
+      },
+      "Attributes": [
+        {
+          "Name": "standard_name",
+          "Value": "projection_y_coordinate"
+        },
+        {
+          "Name": "long_name",
+          "Value": "y coordinate of projection"
+        },
+        {
+          "Name": "dimensions",
+          "Value": "y"
+        },
+        {
+          "Name": "units",
+          "Value": "m"
+        }
+      ],
+      "_Description": "The pseudo-dimension variable is supplemented with variable attributes (as if it was a dimension variables) to fully specify the Y dimension."
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3SMP$",
+        "VariablePattern": "/Soil_Moisture_Retrieval_Data_AM/lc_type"
+      },
+      "Attributes": [
+        {
+          "Name": "dimensions",
+          "Value": "lc_type"
+        },
+        {
+          "Name": "long_name",
+          "Value": "land cover type"
+        }
+      ],
+      "_Description": "The pseudo-dimension variable is supplemented with variable attributes (as if it was a dimension variable) to clarify the dimension name"
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3SM(P|P_E)",
+        "VariablePattern": "/Soil_Moisture_Retrieval_Data_PM/x"
+      },
+      "Attributes": [
+        {
+          "Name": "standard_name",
+          "Value": "projection_x_coordinate"
+        },
+        {
+          "Name": "long_name",
+          "Value": "x coordinate of projection"
+        },
+        {
+          "Name": "dimensions",
+          "Value": "x"
+        },
+        {
+          "Name": "units",
+          "Value": "m"
+        }
+      ],
+      "_Description": "The pseudo-dimension variable is supplemented with variable attributes (as if it was a dimension variables) to fully specify the X dimension."
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3SM(P|P_E)",
+        "VariablePattern": "/Soil_Moisture_Retrieval_Data_PM/y"
+      },
+      "Attributes": [
+        {
+          "Name": "standard_name",
+          "Value": "projection_y_coordinate"
+        },
+        {
+          "Name": "long_name",
+          "Value": "y coordinate of projection"
+        },
+        {
+          "Name": "dimensions",
+          "Value": "y"
+        },
+        {
+          "Name": "units",
+          "Value": "m"
+        }
+      ],
+      "_Description": "The pseudo-dimension variable is supplemented with variable attributes (as if it was a dimension variables) to fully specify the Y dimension."
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3SMP$",
+        "VariablePattern": "/Soil_Moisture_Retrieval_Data_PM/lc_type"
+      },
+      "Attributes": [
+        {
+          "Name": "dimensions",
+          "Value": "lc_type"
+        },
+        {
+          "Name": "long_name",
+          "Value": "land cover type"
+        }
+      ],
+      "_Description": "The pseudo-dimension variable is supplemented with variable attributes (as if it was a dimension variable) to clarify the dimension name"
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3SMP_E",
+        "VariablePattern": "/Soil_Moisture_Retrieval_Data_Polar_AM/x"
+      },
+      "Attributes": [
+        {
+          "Name": "standard_name",
+          "Value": "projection_x_coordinate"
+        },
+        {
+          "Name": "long_name",
+          "Value": "x coordinate of projection"
+        },
+        {
+          "Name": "dimensions",
+          "Value": "x"
+        },
+        {
+          "Name": "units",
+          "Value": "m"
+        }
+      ],
+      "_Description": "The pseudo-dimension variable is supplemented with variable attributes (as if it was a dimension variables) to fully specify the X dimension."
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3SMP_E",
+        "VariablePattern": "/Soil_Moisture_Retrieval_Data_Polar_AM/y"
+      },
+      "Attributes": [
+        {
+          "Name": "standard_name",
+          "Value": "projection_y_coordinate"
+        },
+        {
+          "Name": "long_name",
+          "Value": "y coordinate of projection"
+        },
+        {
+          "Name": "dimensions",
+          "Value": "y"
+        },
+        {
+          "Name": "units",
+          "Value": "m"
+        }
+      ],
+      "_Description": "The pseudo-dimension variable is supplemented with variable attributes (as if it was a dimension variables) to fully specify the Y dimension."
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3SMP_E",
+        "VariablePattern": "/Soil_Moisture_Retrieval_Data_Polar_PM/x"
+      },
+      "Attributes": [
+        {
+          "Name": "standard_name",
+          "Value": "projection_x_coordinate"
+        },
+        {
+          "Name": "long_name",
+          "Value": "x coordinate of projection"
+        },
+        {
+          "Name": "dimensions",
+          "Value": "x"
+        },
+        {
+          "Name": "units",
+          "Value": "m"
+        }
+      ],
+      "_Description": "The pseudo-dimension variable is supplemented with variable attributes (as if it was a dimension variables) to fully specify the X dimension."
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3SMP_E",
+        "VariablePattern": "/Soil_Moisture_Retrieval_Data_Polar_PM/y"
+      },
+      "Attributes": [
+        {
+          "Name": "standard_name",
+          "Value": "projection_y_coordinate"
+        },
+        {
+          "Name": "long_name",
+          "Value": "y coordinate of projection"
+        },
+        {
+          "Name": "dimensions",
+          "Value": "y"
+        },
+        {
+          "Name": "units",
+          "Value": "m"
+        }
+      ],
+      "_Description": "The pseudo-dimension variable is supplemented with variable attributes (as if it was a dimension variables) to fully specify the Y dimension."
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3FTA",
+        "VariablePattern": "/Freeze_Thaw_Retrieval_Data/x"
+      },
+      "Attributes": [
+        {
+          "Name": "standard_name",
+          "Value": "projection_x_coordinate"
+        },
+        {
+          "Name": "long_name",
+          "Value": "x coordinate of projection"
+        },
+        {
+          "Name": "dimensions",
+          "Value": "x"
+        },
+        {
+          "Name": "units",
+          "Value": "m"
+        }
+      ],
+      "_Description": "The pseudo-dimension variable is here supplemented with variable attributes (as if it was a dimension variables) to fully specify the X dimension."
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3FTA",
+        "VariablePattern": "/Freeze_Thaw_Retrieval_Data/y"
+      },
+      "Attributes": [
+        {
+          "Name": "standard_name",
+          "Value": "projection_y_coordinate"
+        },
+        {
+          "Name": "long_name",
+          "Value": "y coordinate of projection"
+        },
+        {
+          "Name": "dimensions",
+          "Value": "y"
+        },
+        {
+          "Name": "units",
+          "Value": "m"
+        }
+      ],
+      "_Description": "The pseudo-dimension variable is here supplemented with variable attributes (as if it was a dimension variables) to fully specify the Y dimension."
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3FTA",
+        "VariablePattern": "/Freeze_Thaw_Retrieval_Data/am_pm"
+      },
+      "Attributes": [
+        {
+          "Name": "dimensions",
+          "Value": "am_pm"
+        },
+        {
+          "Name": "long_name",
+          "Value": "AM-PM dimension of size 2, 0 => AM, 1=> PM"
+        }
+      ],
+      "_Description": "The pseudo-dimension variable is here supplemented with variable attributes (as if it was a dimension variables) to clarify the dimension name"
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3FT(P|P_E)",
+        "VariablePattern": "/Freeze_Thaw_Retrieval_Data_Global/x"
+      },
+      "Attributes": [
+        {
+          "Name": "standard_name",
+          "Value": "projection_x_coordinate"
+        },
+        {
+          "Name": "long_name",
+          "Value": "x coordinate of projection"
+        },
+        {
+          "Name": "dimensions",
+          "Value": "x"
+        },
+        {
+          "Name": "units",
+          "Value": "m"
+        }
+      ],
+      "_Description": "The pseudo-dimension variable is here supplemented with variable attributes (as if it was a dimension variables) to fully specify the X dimension."
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3FT(P|P_E)",
+        "VariablePattern": "/Freeze_Thaw_Retrieval_Data_Global/y"
+      },
+      "Attributes": [
+        {
+          "Name": "standard_name",
+          "Value": "projection_y_coordinate"
+        },
+        {
+          "Name": "long_name",
+          "Value": "y coordinate of projection"
+        },
+        {
+          "Name": "dimensions",
+          "Value": "y"
+        },
+        {
+          "Name": "units",
+          "Value": "m"
+        }
+      ],
+      "_Description": "The pseudo-dimension variable is here supplemented with variable attributes (as if it was a dimension variables) to fully specify the Y dimension."
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3FT(P|P_E)",
+        "VariablePattern": "/Freeze_Thaw_Retrieval_Data_Global/am_pm"
+      },
+      "Attributes": [
+        {
+          "Name": "dimensions",
+          "Value": "am_pm"
+        },
+        {
+          "Name": "long_name",
+          "Value": "AM-PM dimension of size 2, 0 => AM, 1=> PM"
+        }
+      ],
+      "_Description": ""
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3FT(P|P_E)",
+        "VariablePattern": "/Freeze_Thaw_Retrieval_Data_Polar/x"
+      },
+      "Attributes": [
+        {
+          "Name": "standard_name",
+          "Value": "projection_x_coordinate"
+        },
+        {
+          "Name": "long_name",
+          "Value": "x coordinate of projection"
+        },
+        {
+          "Name": "dimensions",
+          "Value": "x"
+        },
+        {
+          "Name": "units",
+          "Value": "m"
+        }
+      ],
+      "_Description": "The pseudo-dimension variable is here supplemented with variable attributes (as if it was a dimension variables) to fully specify the X dimension."
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3FT(P|P_E)",
+        "VariablePattern": "/Freeze_Thaw_Retrieval_Data_Polar/y"
+      },
+      "Attributes": [
+        {
+          "Name": "standard_name",
+          "Value": "projection_y_coordinate"
+        },
+        {
+          "Name": "long_name",
+          "Value": "y coordinate of projection"
+        },
+        {
+          "Name": "dimensions",
+          "Value": "y"
+        },
+        {
+          "Name": "units",
+          "Value": "m"
+        }
+      ],
+      "_Description": "The pseudo-dimension variable is here supplemented with variable attributes (as if it was a dimension variables) to fully specify the Y dimension."
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3FT(P|P_E)",
+        "VariablePattern": "/Freeze_Thaw_Retrieval_Data_Polar/am_pm"
+      },
+      "Attributes": [
+        {
+          "Name": "dimensions",
+          "Value": "am_pm"
+        },
+        {
+          "Name": "long_name",
+          "Value": "AM-PM dimension of size 2, 0 => AM, 1=> PM"
+        }
+      ],
+      "_Description": "SMAP L3 data are HDF5 and without dimension settings. Overrides here define the dimensions, a useful reference name, and critically, the dimension order."
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3SM(AP|P_E)|SPL2SMAP_S",
+        "VariablePattern": "/Soil_Moisture_Retrieval_(?:Data(?:_AM|_Polar_AM|_1km|_3km)?)/(?!x$|y$).+$"
+      },
+      "Attributes": [
+        {
+          "Name": "dimensions",
+          "Value": "y x"
+        }
+      ],
+      "_Description": "SMAP L3 data are HDF5 and without dimension settings. Overrides here define the dimensions, a useful reference name, and critically, the dimension order."
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3SMA$",
+        "VariablePattern": "/Soil_Moisture_Retrieval_Data/(?!x$|y$).+$|/(Radar_Data|Ancillary_Data)/.*"
+      },
+      "Attributes": [
+        {
+          "Name": "dimensions",
+          "Value": "y x"
+        }
+      ],
+      "_Description": "SMAP L3 data are HDF5 and without dimension settings. Overrides here define the dimensions, a useful reference name, and critically, the dimension order."
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3SMP",
+        "VariablePattern": "/Soil_Moisture_Retrieval_Data_(AM|PM)?/(?!x$|y$|landcover.*$|lc_type$).+$"
+      },
+      "Attributes": [
+        {
+          "Name": "dimensions",
+          "Value": "y x"
+        }
+      ],
+      "_Description": "SMAP L3 data are HDF5 and without dimension settings. Overrides here define the dimensions, a useful reference name, and critically, the dimension order."
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3SMP",
+        "VariablePattern": ".*landcover.*"
+      },
+      "Attributes": [
+        {
+          "Name": "dimensions",
+          "Value": "y x lc_type"
+        }
+      ],
+      "_Description": "SMAP L3 data are HDF5 and without dimension settings. Overrides here define the dimensions, a useful reference name, and critically, the dimension order."
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3FT(P|P_E)",
+        "VariablePattern": "/Freeze_Thaw_Retrieval_Data(?:_(Global|Polar))?/(?!transition_state_flag$|transition_direction$|am_pm$|x$|y$).+$|/Radar_Data/.*"
+      },
+      "Attributes": [
+        {
+          "Name": "dimensions",
+          "Value": "am_pm y x"
+        }
+      ],
+      "_Description": "SMAP L3 data are HDF5 and without dimension settings. Overrides here define the dimensions, a useful reference name, and critically, the dimension order."
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3FTA",
+        "VariablePattern": "/Freeze_Thaw_Retrieval_Data/(?!transition_state_flag$|transition_direction$|am_pm$|x$|y$).+$|/(Radar_Data|Ancillary_Data)/.*"
+      },
+      "Attributes": [
+        {
+          "Name": "dimensions",
+          "Value": "am_pm y x"
+        }
+      ],
+      "_Description": "SMAP L3 data are HDF5 and without dimension settings. Overrides here define the dimensions, a useful reference name, and critically, the dimension order."
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3FT(A|P|P_E)",
+        "VariablePattern": "/Freeze_Thaw_Retrieval_Data(?:_(Global|Polar))?/(transition_direction|transition_state_flag)$"
+      },
+      "Attributes": [
+        {
+          "Name": "dimensions",
+          "Value": "y x"
+        }
+      ],
+      "_Description": "SMAP L3 data are HDF5 and without dimension settings. Overrides here define the dimensions, a useful reference name, and critically, the dimension order."
     }
   ]
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,7 +113,7 @@ def expected_output_netcdf4_file(temp_dir) -> str:
                 'history': f'2000-01-02T03:04:05+00:00 {PROGRAM} {VERSION}',
             },
             data_vars={
-                'EASE2_polar_projection': xr.DataArray(
+                'EASE2_north_polar_projection_36km': xr.DataArray(
                     b'',
                     attrs={
                         'false_easting': 0.0,
@@ -121,6 +121,7 @@ def expected_output_netcdf4_file(temp_dir) -> str:
                         'grid_mapping_name': 'lambert_azimuthal_equal_area',
                         'latitude_of_projection_origin': 90.0,
                         'longitude_of_projection_origin': 0.0,
+                        'master_geotransform': [-9000000, 36000, 0, 9000000, 0, -36000],
                     },
                 ),
                 'variable_one': xr.DataArray(
@@ -128,7 +129,7 @@ def expected_output_netcdf4_file(temp_dir) -> str:
                     attrs={
                         '_FillValue': -9999.0,
                         'coordinates': 'time latitude longitude',
-                        'grid_mapping': '/EASE2_polar_projection',
+                        'grid_mapping': '/EASE2_north_polar_projection_36km',
                         'units': 'seconds since 2000-00-00T12:34:56',
                     },
                 ),

--- a/tests/data/earthdata_varinfo_test_config.json
+++ b/tests/data/earthdata_varinfo_test_config.json
@@ -73,7 +73,7 @@
         },
         {
           "Name": "grid_mapping",
-          "Value": "/EASE2_polar_projection"
+          "Value": "/EASE2_north_polar_projection_36km"
         }
       ],
       "_Description": "Adding a new attribute and updating an existing attribute on an existing variable."
@@ -100,7 +100,7 @@
       "Applicability": {
         "Mission": "TEST_MISSION",
         "ShortNamePath": "TEST01",
-        "VariablePattern": "/EASE2_polar_projection"
+        "VariablePattern": "/EASE2_north_polar_projection_36km"
       },
       "Attributes": [
         {
@@ -122,6 +122,10 @@
         {
           "Name": "false_northing",
           "Value": 0.0
+        },
+        {
+          "Name": "master_geotransform",
+          "Value": [-9000000, 36000, 0, 9000000, 0, -36000]
         }
       ],
       "_Description": "Adding a new attribute-only variable with specified attributes."

--- a/tests/unit/test_annotate.py
+++ b/tests/unit/test_annotate.py
@@ -109,7 +109,7 @@ def test_update_metadata_attributes_variable(sample_netcdf4_file, sample_varinfo
         # grid_mapping is a new attribute added due to the configuration file
         assert (
             test_datatree['/variable_one'].attrs['grid_mapping']
-            == '/EASE2_polar_projection'
+            == '/EASE2_north_polar_projection_36km'
         )
 
 
@@ -159,11 +159,11 @@ def test_get_matching_groups_and_variables(sample_varinfo):
         ['/', '/sub_group', '/variable_one', '/sub_group/variable_two']
     )
 
-    # The /EASE2_polar_projection variable is specifically included in the
+    # The /EASE2_north_polar_projection_36km variable is specifically included in the
     # configuration file to test missing variable behaviour.
     assert missing_variables == set(
         [
-            '/EASE2_polar_projection',
+            '/EASE2_north_polar_projection_36km',
         ]
     )
 


### PR DESCRIPTION
## Description

This PR includes the following changes to the varinfo configuration:

- updates to make the global grid mapping variables resolution specific and addition of a master_geotransform attribute to all grid mapping variables
- updates to add missing dimension variables and add a dimensions attribute to their associated variables


## Jira Issue ID
[DAS-2297](https://bugs.earthdata.nasa.gov/browse/DAS-2297)

## Local Test Steps

- Clone this repository and checkout the DAS-2297 branch
- Run the unit tests and ensure they all pass
`./bin/build-image && ./bin/build-test && ./bin/run-test`
- Follow the instructions in README.md to enable the service in harmony-in-a-box
- In harmony-in-a-box, run the test requests detailed in the comments of [DAS-2297](https://bugs.earthdata.nasa.gov/browse/DAS-2297).
  - For each request, download the output from the local staging bucket. You can find the download url in the job status page on harmony.
  - Inspect that the outputs for the following:
    - the correct grid mapping variable(s) and the correct variable attributes have been created
    - all science variables have the grid mapping attribute referencing the grid mapping variable (except for any variables excluded in the configuration)
    - the correct dimension variables (x, y, etc…) have been created
    - all science variables have a dimension attribute with the correct dimensions specified


## PR Acceptance Checklist

* [x] Jira ticket acceptance criteria met.
* [x] `CHANGELOG.md` updated to include high level summary of PR changes.
* [ ] `docker/service_version.txt` updated if publishing a release.
* [ ] Tests added/updated and passing.
* [ ] Documentation updated (if needed).
