### PR TITLE
DAS-2338: Create dimension scales based on the row/col indexes and master geotransform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased] - 2025-05-06
 
-- Update the Harmony Metadata Annotator to update spatial dimension variables with a dimension
-  scale that is computed based off the associated grid mapping variable's `master_geotransform` and
-  the determined grid start index. Currently, the grid start index can be determined from the
-  dimension's associated row/col index variable.
+- Update spatial dimension variables with a dimension scale that is computed based off the
+  associated grid mapping variable's `master_geotransform` and the determined grid start index.
+  Currently, the grid start index can be determined from the dimension's associated row/col index
+  variable.
 
 
 ## [unreleased] - 2025-04-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased] - 2025-05-06
+
+- Update the Harmony Metadata Annotator to update spatial dimension variables with a dimension
+  scale that is computed based off the associated grid mapping variable's `master_geotransform` and
+  the determined grid start index. Currently, the grid start index can be determined from the
+  dimension's associated row/col index variable.
+
+
 ## [unreleased] - 2025-04-24
 
 - Update Harmony Metadata Annotator to rename pseudo dimension variables

--- a/metadata_annotator/annotate.py
+++ b/metadata_annotator/annotate.py
@@ -421,10 +421,9 @@ def get_spatial_dimension_type(data_array: xr.DataArray) -> str:
         raise MissingDimensionAttribute(data_array.name, 'standard_name')
     if standard_name == 'projection_x_coordinate':
         return 'x'
-    elif standard_name == 'projection_y_coordinate':
+    if standard_name == 'projection_y_coordinate':
         return 'y'
-    else:
-        raise InvalidDimensionAttribute(data_array.name, 'standard_name', standard_name)
+    raise InvalidDimensionAttribute(data_array.name, 'standard_name', standard_name)
 
 
 def get_geotransform_config(

--- a/metadata_annotator/annotate.py
+++ b/metadata_annotator/annotate.py
@@ -400,19 +400,19 @@ def get_start_index_from_row_col_variable(
 ) -> tuple[int, int]:
     """Return the grid start index from a row or column index variable.
 
-    The subset_index_reference must correspond to a variable in the datatree that
-    has at least two dimensions. The value at the [0, 0] position in the last two
-    dimensions (assumed to be y, x) is returned as the grid start index.
+    The subset_index_reference must correspond to a 2D variable in the datatree.
+    The value at the [0, 0] is returned as the grid start index.
     """
     try:
         row_col_variable = datatree[subset_index_reference]
     except KeyError as e:
         raise MissingSubsetIndexReference(subset_index_reference) from e
 
-    if row_col_variable.ndim < 2:
+    # To be improved - extend to support 3D variables
+    if row_col_variable.ndim != 2:
         raise InvalidSubsetIndexShape(subset_index_reference)
 
-    return row_col_variable.values[..., 0, 0].item()
+    return row_col_variable.values[0][0]
 
 
 def get_spatial_dimension_type(data_array: xr.DataArray) -> str:

--- a/metadata_annotator/annotate.py
+++ b/metadata_annotator/annotate.py
@@ -354,7 +354,10 @@ def update_spatial_dimension_values(
 ) -> None:
     """Update the spatial dimension variable values to the computed dimension scale."""
     for variable_path in dimension_variables:
-        dim_data_array = datatree[variable_path]
+        try:
+            dim_data_array = datatree[variable_path]
+        except KeyError:
+            raise Exception(f'Unable to find dimension variable "{variable_path}"')
 
         grid_start_index = get_grid_start_index(datatree, dim_data_array)
         dimension_size = len(dim_data_array)

--- a/metadata_annotator/annotate.py
+++ b/metadata_annotator/annotate.py
@@ -337,14 +337,13 @@ def get_spatial_dimension_variables(
     data_tree: xr.DataTree, variables: set[str] = None
 ) -> set[str]:
     """Return a set of identified spatial dimension variables."""
-    spatial_dimension_variables = set()
     valid_dim_standard_names = ('projection_x_coordinate', 'projection_y_coordinate')
-    for variable_path in variables:
-        standard_name = data_tree[variable_path].attrs.get('standard_name', None)
-        if standard_name in valid_dim_standard_names:
-            spatial_dimension_variables.add(variable_path)
-
-    return spatial_dimension_variables
+    return set(
+        variable_path
+        for variable_path in variables
+        if data_tree[variable_path].attrs.get('standard_name', None)
+        in valid_dim_standard_names
+    )
 
 
 def update_spatial_dimension_values(

--- a/metadata_annotator/annotate.py
+++ b/metadata_annotator/annotate.py
@@ -81,7 +81,7 @@ def amend_in_file_metadata(
             if variable_path not in dimension_variables:
                 create_new_variables(datatree, variable_path, granule_varinfo)
             else:
-                update_dimension_variables(datatree, variable_path, granule_varinfo)
+                update_dimension_variable(datatree, variable_path, granule_varinfo)
         update_history_metadata(datatree)
 
         # Future improvement: It is memory intensive to try and write out the
@@ -276,10 +276,10 @@ def get_dimension_variables(
     return dimension_variables
 
 
-def update_dimension_variables(
+def update_dimension_variable(
     datatree: xr.DataTree, variable_path: str, granule_varinfo: VarInfoFromNetCDF4
 ) -> None:
-    """Update attributes of dimension variables based on json configuration."""
+    """Update attributes of a dimension variable based on json configuration."""
     group_path, dimension_name = os.path.split(variable_path)
     dt_group = datatree[group_path]
     dataset = xr.Dataset(dt_group)

--- a/metadata_annotator/earthdata_varinfo_config.json
+++ b/metadata_annotator/earthdata_varinfo_config.json
@@ -161,7 +161,7 @@
       "Applicability": {
         "Mission": "SMAP",
         "ShortNamePath": "SPL3FTA",
-        "VariablePattern": "/(Freeze_Thaw_Retrieval_Data|Radar_Data|Ancillary_Data)/.*|/(x|y)"
+        "VariablePattern": "/(Freeze_Thaw_Retrieval_Data|Radar_Data|Ancillary_Data)/(?!am_pm$).+$"
       },
       "Attributes": [
         {
@@ -203,7 +203,7 @@
       "Applicability": {
         "Mission": "SMAP",
         "ShortNamePath": "SPL3SMA$",
-        "VariablePattern": "/(Soil_Moisture_Retrieval_Data|Radar_Data|Ancillary_Data)/.*|/(x|y)"
+        "VariablePattern": "/(Soil_Moisture_Retrieval_Data|Radar_Data|Ancillary_Data)/.*"
       },
       "Attributes": [
         {
@@ -1058,8 +1058,8 @@
     {
       "Applicability": {
         "Mission": "SMAP",
-        "ShortNamePath": "SPL3FTA|SPL3SMA$",
-        "VariablePattern": "/x"
+        "ShortNamePath": "SPL3FTA",
+        "VariablePattern": "/Freeze_Thaw_Retrieval_Data/x"
       },
       "Attributes": [
         {
@@ -1093,7 +1093,143 @@
       "Applicability": {
         "Mission": "SMAP",
         "ShortNamePath": "SPL3FTA|SPL3SMA$",
-        "VariablePattern": "/y"
+        "VariablePattern": "/Ancillary_Data/x"
+      },
+      "Attributes": [
+        {
+          "Name": "standard_name",
+          "Value": "projection_x_coordinate"
+        },
+        {
+          "Name": "long_name",
+          "Value": "x coordinate of projection"
+        },
+        {
+          "Name": "dimensions",
+          "Value": "x"
+        },
+        {
+          "Name": "axis",
+          "Value": "X"
+        },
+        {
+          "Name": "units",
+          "Value": "m"
+        },
+        {
+          "Name": "type",
+          "Value": "float64"
+        }
+      ],
+      "_Description": "The pseudo-dimension variable is here supplemented with variable attributes (as if it was a dimension variables) to fully specify the X dimension."
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3FTA|SPL3SMA$",
+        "VariablePattern": "/Radar_Data/x"
+      },
+      "Attributes": [
+        {
+          "Name": "standard_name",
+          "Value": "projection_x_coordinate"
+        },
+        {
+          "Name": "long_name",
+          "Value": "x coordinate of projection"
+        },
+        {
+          "Name": "dimensions",
+          "Value": "x"
+        },
+        {
+          "Name": "axis",
+          "Value": "X"
+        },
+        {
+          "Name": "units",
+          "Value": "m"
+        },
+        {
+          "Name": "type",
+          "Value": "float64"
+        }
+      ],
+      "_Description": "The pseudo-dimension variable is here supplemented with variable attributes (as if it was a dimension variables) to fully specify the X dimension."
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3FTA",
+        "VariablePattern": "/Freeze_Thaw_Retrieval_Data/y"
+      },
+      "Attributes": [
+        {
+          "Name": "standard_name",
+          "Value": "projection_y_coordinate"
+        },
+        {
+          "Name": "long_name",
+          "Value": "y coordinate of projection"
+        },
+        {
+          "Name": "dimensions",
+          "Value": "y"
+        },
+        {
+          "Name": "axis",
+          "Value": "Y"
+        },
+        {
+          "Name": "units",
+          "Value": "m"
+        },
+        {
+          "Name": "type",
+          "Value": "float64"
+        }
+      ],
+      "_Description": "The pseudo-dimension variable is here supplemented with variable attributes (as if it was a dimension variables) to fully specify the Y dimension."
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3FTA|SPL3SMA$",
+        "VariablePattern": "/Ancillary_Data/y"
+      },
+      "Attributes": [
+        {
+          "Name": "standard_name",
+          "Value": "projection_y_coordinate"
+        },
+        {
+          "Name": "long_name",
+          "Value": "y coordinate of projection"
+        },
+        {
+          "Name": "dimensions",
+          "Value": "y"
+        },
+        {
+          "Name": "axis",
+          "Value": "Y"
+        },
+        {
+          "Name": "units",
+          "Value": "m"
+        },
+        {
+          "Name": "type",
+          "Value": "float64"
+        }
+      ],
+      "_Description": "The pseudo-dimension variable is here supplemented with variable attributes (as if it was a dimension variables) to fully specify the Y dimension."
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3FTA|SPL3SMA$",
+        "VariablePattern": "/Radar_Data/y"
       },
       "Attributes": [
         {
@@ -1127,7 +1263,7 @@
       "Applicability": {
         "Mission": "SMAP",
         "ShortNamePath": "SPL3FTA",
-        "VariablePattern": "/am_pm"
+        "VariablePattern": "/Freeze_Thaw_Retrieval_Data/am_pm"
       },
       "Attributes": [
         {
@@ -1144,6 +1280,118 @@
         }
       ],
       "_Description": "The pseudo-dimension variable is here supplemented with variable attributes (as if it was a dimension variables) to clarify the dimension name"
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3FTA",
+        "VariablePattern": "/Ancillary_Data/am_pm"
+      },
+      "Attributes": [
+        {
+          "Name": "dimensions",
+          "Value": "am_pm"
+        },
+        {
+          "Name": "long_name",
+          "Value": "AM-PM dimension of size 2, 0 => AM, 1=> PM"
+        },
+        {
+          "Name": "type",
+          "Value": "uint8"
+        }
+      ],
+      "_Description": "The pseudo-dimension variable is here supplemented with variable attributes (as if it was a dimension variables) to clarify the dimension name"
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3FTA",
+        "VariablePattern": "/Radar_Data/am_pm"
+      },
+      "Attributes": [
+        {
+          "Name": "dimensions",
+          "Value": "am_pm"
+        },
+        {
+          "Name": "long_name",
+          "Value": "AM-PM dimension of size 2, 0 => AM, 1=> PM"
+        },
+        {
+          "Name": "type",
+          "Value": "uint8"
+        }
+      ],
+      "_Description": "The pseudo-dimension variable is here supplemented with variable attributes (as if it was a dimension variables) to clarify the dimension name"
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3SMA$",
+        "VariablePattern": "/Soil_Moisture_Retrieval_Data/x"
+      },
+      "Attributes": [
+        {
+          "Name": "standard_name",
+          "Value": "projection_x_coordinate"
+        },
+        {
+          "Name": "long_name",
+          "Value": "x coordinate of projection"
+        },
+        {
+          "Name": "dimensions",
+          "Value": "x"
+        },
+        {
+          "Name": "axis",
+          "Value": "X"
+        },
+        {
+          "Name": "units",
+          "Value": "m"
+        },
+        {
+          "Name": "type",
+          "Value": "float64"
+        }
+      ],
+      "_Description": "The pseudo-dimension variable is here supplemented with variable attributes (as if it was a dimension variables) to fully specify the X dimension."
+    },
+    {
+      "Applicability": {
+        "Mission": "SMAP",
+        "ShortNamePath": "SPL3SMA$",
+        "VariablePattern": "/Soil_Moisture_Retrieval_Data/y"
+      },
+      "Attributes": [
+        {
+          "Name": "standard_name",
+          "Value": "projection_y_coordinate"
+        },
+        {
+          "Name": "long_name",
+          "Value": "y coordinate of projection"
+        },
+        {
+          "Name": "dimensions",
+          "Value": "y"
+        },
+        {
+          "Name": "axis",
+          "Value": "Y"
+        },
+        {
+          "Name": "units",
+          "Value": "m"
+        },
+        {
+          "Name": "type",
+          "Value": "float64"
+        }
+      ],
+      "_Description": "The pseudo-dimension variable is here supplemented with variable attributes (as if it was a dimension variables) to fully specify the Y dimension."
     },
     {
       "Applicability": {
@@ -1343,7 +1591,7 @@
       "Applicability": {
         "Mission": "SMAP",
         "ShortNamePath": "SPL3SMA$",
-        "VariablePattern": "/(Soil_Moisture_Retrieval_Data|Radar_Data|Ancillary_Data)/.*"
+        "VariablePattern": "/(Soil_Moisture_Retrieval_Data|Radar_Data|Ancillary_Data)/(?!x$|y$).+$"
       },
       "Attributes": [
         {
@@ -1399,7 +1647,7 @@
       "Applicability": {
         "Mission": "SMAP",
         "ShortNamePath": "SPL3FTA",
-        "VariablePattern": "/Freeze_Thaw_Retrieval_Data/(?!transition_state_flag$|transition_direction$).+$|/(Radar_Data|Ancillary_Data)/.*"
+        "VariablePattern": "/(Freeze_Thaw_Retrieval_Data|Radar_Data|Ancillary_Data)/(?!transition_state_flag$|transition_direction$|am_pm$|x$|y$).+$"
       },
       "Attributes": [
         {

--- a/metadata_annotator/earthdata_varinfo_config.json
+++ b/metadata_annotator/earthdata_varinfo_config.json
@@ -565,6 +565,10 @@
         {
           "Name": "type",
           "Value": "float64"
+        },
+        {
+          "Name": "subset_index_reference",
+          "Value": "/Soil_Moisture_Retrieval_Data_1km/EASE_column_index_1km"
         }
       ],
       "_Description": "The pseudo-dimension variable is supplemented with variable attributes (as if it was a dimension variables) to fully specify the X dimension."
@@ -599,6 +603,10 @@
         {
           "Name": "type",
           "Value": "float64"
+        },
+        {
+          "Name": "subset_index_reference",
+          "Value": "/Soil_Moisture_Retrieval_Data_1km/EASE_row_index_1km"
         }
       ],
       "_Description": "The pseudo-dimension variable is supplemented with variable attributes (as if it was a dimension variables) to fully specify the Y dimension."
@@ -633,6 +641,10 @@
         {
           "Name": "type",
           "Value": "float64"
+        },
+        {
+          "Name": "subset_index_reference",
+          "Value": "/Soil_Moisture_Retrieval_Data_3km/EASE_column_index_3km"
         }
       ],
       "_Description": "The pseudo-dimension variable is supplemented with variable attributes (as if it was a dimension variables) to fully specify the X dimension."
@@ -667,6 +679,10 @@
         {
           "Name": "type",
           "Value": "float64"
+        },
+        {
+          "Name": "subset_index_reference",
+          "Value": "/Soil_Moisture_Retrieval_Data_3km/EASE_row_index_3km"
         }
       ],
       "_Description": "The pseudo-dimension variable is supplemented with variable attributes (as if it was a dimension variables) to fully specify the Y dimension."

--- a/metadata_annotator/exceptions.py
+++ b/metadata_annotator/exceptions.py
@@ -13,5 +13,64 @@ class InvalidSpatialDimensionType(MetadataAnnotatorError):
     """Raised when a spatial dimension type is not 'x' or 'y'."""
 
     def __init__(self, spatial_dimension_type):
-        """Initialize the exception with the provided spatial dimension type."""
+        """Initialize the exception with the spatial dimension type."""
         super().__init__(f'Invalid spatial dimension type: "{spatial_dimension_type}"')
+
+
+class MissingDimensionAttribute(MetadataAnnotatorError):
+    """Raised when a required metadata attribute is missing from a dimension."""
+
+    def __init__(self, variable_name, attribute_name):
+        """Initialize the exception with the variable name and attribute name."""
+        super().__init__(
+            f'Dimension variable "{variable_name}" does not have '
+            f'an associated "{attribute_name}" metadata attribute.',
+        )
+
+
+class InvalidDimensionAttribute(MetadataAnnotatorError):
+    """Raised when a dimension variable's metadata attribute is present but invalid."""
+
+    def __init__(self, variable_name, attribute_name, attribute_value):
+        """Initialize the exception with variable name, attribute name, and value."""
+        super().__init__(
+            f'Dimension variable "{variable_name}" has an invalid "{attribute_name} '
+            f'value: "{attribute_value}".'
+        )
+
+
+class InvalidGridMappingReference(MetadataAnnotatorError):
+    """Raised when the grid mapping variable is missing in earthdata_varinfo."""
+
+    def __init__(self, grid_mapping_reference):
+        """Initialize the exception with the grid mapping reference."""
+        super().__init__(
+            f'Could not find grid mapping reference variable '
+            f'"{grid_mapping_reference}"',
+        )
+
+
+class MissingSubsetIndexReference(MetadataAnnotatorError):
+    """Raised when the row or column index variable is missing in earthdata_varinfo."""
+
+    def __init__(self, row_col_index_variable):
+        """Initialize the exception with the row/col index reference variable."""
+        super().__init__(
+            f'Could not find row/column index reference variable '
+            f'"{row_col_index_variable}"',
+        )
+
+
+class MissingStartIndexConfiguration(MetadataAnnotatorError):
+    """Raised when method to select start index configuration is missing.
+
+    A dimension variable require's a valid attribute to dictate which method to use to
+    select the start index.
+    """
+
+    def __init__(self, dimension_name):
+        """Initialize the exception with the dimension name."""
+        super().__init__(
+            f'Missing index range configuration attribute for dimension variable '
+            f'"{dimension_name}"',
+        )

--- a/metadata_annotator/exceptions.py
+++ b/metadata_annotator/exceptions.py
@@ -53,11 +53,21 @@ class InvalidGridMappingReference(MetadataAnnotatorError):
 class MissingSubsetIndexReference(MetadataAnnotatorError):
     """Raised when the row or column index variable is missing in earthdata_varinfo."""
 
-    def __init__(self, row_col_index_variable):
+    def __init__(self, variable_name):
         """Initialize the exception with the row/col index reference variable."""
         super().__init__(
-            f'Could not find row/column index reference variable '
-            f'"{row_col_index_variable}"',
+            f'Could not find row/column index reference variable "{variable_name}"',
+        )
+
+
+class InvalidSubsetIndexShape(MetadataAnnotatorError):
+    """Raised when the index variable does not have at least two dimensions."""
+
+    def __init__(self, variable_name):
+        """Initialize the exception with the row/col index reference variable."""
+        super().__init__(
+            f'The row/column index reference variable '
+            f'"{variable_name}" must have at least two dimensions.'
         )
 
 

--- a/metadata_annotator/exceptions.py
+++ b/metadata_annotator/exceptions.py
@@ -1,0 +1,17 @@
+"""Module defining custom exceptions."""
+
+
+class MetadataAnnotatorError(Exception):
+    """Base error class for exceptions raised by metadata_annotator library."""
+
+    def __init__(self, message=None):
+        """All Metadata Annotator service errors have a message field."""
+        self.message = message
+
+
+class InvalidSpatialDimensionType(MetadataAnnotatorError):
+    """Raised when a spatial dimension type is not 'x' or 'y'."""
+
+    def __init__(self, spatial_dimension_type):
+        """Initialize the exception with the provided spatial dimension type."""
+        super().__init__(f'Invalid spatial dimension type: "{spatial_dimension_type}"')

--- a/metadata_annotator/geotransform.py
+++ b/metadata_annotator/geotransform.py
@@ -1,0 +1,91 @@
+"""Info particular to creating dimension scales from a geotransform."""
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from metadata_annotator.exceptions import InvalidSpatialDimensionType
+
+
+@dataclass
+class Geotransform:
+    """Class for holding a GDAL-style 6-element geotransform."""
+
+    top_left_x: np.float64
+    pixel_width: np.float64
+    row_rotation: np.float64
+    top_left_y: np.float64
+    column_rotation: np.float64
+    pixel_height: np.float64
+
+    def col_row_to_xy(self, col: int, row: int) -> tuple[np.float64, np.float64]:
+        """Convert grid cell location to x,y coordinate."""
+        # Geotransform is defined from upper left corner as (0,0), so adjust
+        # input value to the center of grid at (.5, .5)
+        adj_col = col + 0.5
+        adj_row = row + 0.5
+
+        x = self.top_left_x + adj_col * self.pixel_width + adj_row * self.row_rotation
+        y = (
+            self.top_left_y
+            + adj_col * self.column_rotation
+            + adj_row * self.pixel_height
+        )
+        return x, y
+
+
+def geotransform_from_config(geotransform_info: list) -> Geotransform:
+    """Return a geotransform object from the geotransform configuration list.
+
+    The geotransform configuration is a list of six elements that describe the spatial
+    transformation for a grid. The elements correspond to the following values:
+
+    GT(0) x-coordinate of the upper-left corner of the upper-left pixel.
+    GT(1) w-e pixel resolution / pixel width.
+    GT(2) row rotation (typically zero).
+    GT(3) y-coordinate of the upper-left corner of the upper-left pixel.
+    GT(4) column rotation (typically zero).
+    GT(5) n-s pixel resolution / pixel height (negative value for a north-up image).
+
+    """
+    return Geotransform(
+        geotransform_info[0],
+        geotransform_info[1],
+        geotransform_info[2],
+        geotransform_info[3],
+        geotransform_info[4],
+        geotransform_info[5],
+    )
+
+
+def compute_dimension_scale(
+    start_index: int,
+    dim_size: int,
+    spatial_dimension_type: str,
+    dimension_value_dtype: str,
+    geotransform_config: list,
+) -> np.ndarray:
+    """Compute the dimension scale from the given geotransform configuration."""
+    geotransform = geotransform_from_config(geotransform_config)
+
+    # compute the x,y locations along a column and row
+    if spatial_dimension_type == 'x':
+        column_dimensions = [
+            geotransform.col_row_to_xy(i, 0)
+            for i in range(start_index, start_index + dim_size)
+        ]
+        dimension_scale = np.array(
+            [x for x, y in column_dimensions], dtype=np.dtype(dimension_value_dtype)
+        )
+    elif spatial_dimension_type == 'y':
+        row_dimensions = [
+            geotransform.col_row_to_xy(0, i)
+            for i in range(start_index, start_index + dim_size)
+        ]
+        dimension_scale = np.array(
+            [y for x, y in row_dimensions], dtype=np.dtype(dimension_value_dtype)
+        )
+    else:
+        raise InvalidSpatialDimensionType(spatial_dimension_type)
+
+    return dimension_scale

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -257,18 +257,18 @@ def sample_netcdf4_file_test02(temp_dir) -> str:
                     },
                     dims=['y'],
                 ),
-                'z': xr.DataArray(
-                    np.array([]),
+                'variable_one': xr.DataArray(
+                    np.ones((3, 3)),
                     attrs={
                         'standard_name': 'invalid_standard_name',
                         'grid_mapping': '/EASE2_variable_missing_geotransform',
                     },
-                    dims=['z'],
+                    dims=['y', 'x'],
                 ),
-                'am_pm': xr.DataArray(
-                    np.array([]),
+                'variable_two': xr.DataArray(
+                    np.ones((3, 3)),
                     attrs={},
-                    dims=['am_pm'],
+                    dims=['y', 'x'],
                 ),
                 'EASE_column_index': xr.DataArray(
                     np.array([[5, 6, 7], [5, 6, 7], [5, 6, 7]]),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -226,3 +226,73 @@ def sample_harmony_message() -> HarmonyMessage:
             'user': 'fakeuser',
         }
     )
+
+
+@fixture(scope='function')
+def sample_netcdf4_file_test02(temp_dir) -> str:
+    """Create a sample NetCDF-4 file."""
+    file_name = path_join(temp_dir, 'test_input_02.nc')
+
+    sample_datatree = xr.DataTree(
+        dataset=xr.Dataset(
+            attrs={
+                'short_name': 'TEST02',
+            },
+            data_vars={
+                'x': xr.DataArray(
+                    np.array([0, 1, 2]),
+                    attrs={
+                        'standard_name': 'projection_x_coordinate',
+                        'subset_index_reference': 'EASE_column_index',
+                        'grid_mapping': '/EASE2_north_polar_projection_36km',
+                    },
+                    dims=['x'],
+                ),
+                'y': xr.DataArray(
+                    np.array([0, 1, 2]),
+                    attrs={
+                        'standard_name': 'projection_y_coordinate',
+                        'subset_index_reference': 'EASE_row_index',
+                        'grid_mapping': '/EASE2_north_polar_projection_36km',
+                    },
+                    dims=['y'],
+                ),
+                'z': xr.DataArray(
+                    np.array([]),
+                    attrs={
+                        'standard_name': 'invalid_standard_name',
+                        'grid_mapping': '/EASE2_variable_missing_geotransform',
+                    },
+                    dims=['z'],
+                ),
+                'am_pm': xr.DataArray(
+                    np.array([]),
+                    attrs={},
+                    dims=['am_pm'],
+                ),
+                'EASE_column_index': xr.DataArray(
+                    np.array([[5, 6, 7], [5, 6, 7], [5, 6, 7]]),
+                    attrs={},
+                    dims=['y', 'x'],
+                ),
+                'EASE_row_index': xr.DataArray(
+                    np.array([[5, 6, 7], [5, 6, 7], [5, 6, 7]]),
+                    attrs={},
+                    dims=['y', 'x'],
+                ),
+            },
+        ),
+    )
+
+    sample_datatree.to_netcdf(file_name, encoding=None)
+    return file_name
+
+
+@fixture(scope='function')
+def sample_varinfo_test02(
+    sample_netcdf4_file, varinfo_config_file
+) -> VarInfoFromNetCDF4:
+    """Create sample VarInfoFromNetCDF4 instance."""
+    return VarInfoFromNetCDF4(
+        sample_netcdf4_file, config_file=varinfo_config_file, short_name='TEST02'
+    )

--- a/tests/data/earthdata_varinfo_test_config.json
+++ b/tests/data/earthdata_varinfo_test_config.json
@@ -129,6 +129,70 @@
         }
       ],
       "_Description": "Adding a new attribute-only variable with specified attributes."
+    },
+    {
+      "Applicability": {
+        "Mission": "TEST_MISSION",
+        "ShortNamePath": "TEST02",
+        "VariablePattern": "/EASE2_north_polar_projection_36km"
+      },
+      "Attributes": [
+        {
+          "Name": "grid_mapping_name",
+          "Value": "lambert_azimuthal_equal_area"
+        },
+        {
+          "Name": "longitude_of_projection_origin",
+          "Value": 0.0
+        },
+        {
+          "Name": "latitude_of_projection_origin",
+          "Value": 90.0
+        },
+        {
+          "Name": "false_easting",
+          "Value": 0.0
+        },
+        {
+          "Name": "false_northing",
+          "Value": 0.0
+        },
+        {
+          "Name": "master_geotransform",
+          "Value": [-9000000, 36000, 0, 9000000, 0, -36000]
+        }
+      ],
+      "_Description": "Adding a new attribute-only variable with specified attributes."
+    },
+    {
+      "Applicability": {
+        "Mission": "TEST_MISSION",
+        "ShortNamePath": "TEST02",
+        "VariablePattern": "/EASE2_variable_missing_geotransform"
+      },
+      "Attributes": [
+        {
+          "Name": "grid_mapping_name",
+          "Value": "lambert_azimuthal_equal_area"
+        },
+        {
+          "Name": "longitude_of_projection_origin",
+          "Value": 0.0
+        },
+        {
+          "Name": "latitude_of_projection_origin",
+          "Value": 90.0
+        },
+        {
+          "Name": "false_easting",
+          "Value": 0.0
+        },
+        {
+          "Name": "false_northing",
+          "Value": 0.0
+        }
+      ],
+      "_Description": "Adding a new attribute-only variable with missing master_geotransform attribute."
     }
   ]
 }

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -43,6 +43,11 @@ def test_process_item(
     stage_mock = mocker.patch('harmony_service.adapter.stage')
     stage_mock.return_value = 's3://bucketname/staged-location'
 
+    get_spatial_dimension_variables_mock = mocker.patch(
+        'metadata_annotator.annotate.get_spatial_dimension_variables'
+    )
+    get_spatial_dimension_variables_mock.return_value = set()
+
     # Create and run the service
     harmony_config = config(validate=False)
 

--- a/tests/unit/test_annotate.py
+++ b/tests/unit/test_annotate.py
@@ -438,7 +438,7 @@ def test_get_spatial_dimension_variables(sample_netcdf4_file_test02) -> None:
     with xr.open_datatree(
         sample_netcdf4_file_test02, decode_times=False
     ) as test_datatree:
-        variables = {'/x', '/y', '/am_pm'}
+        variables = {'/x', '/y', '/variable_two'}
         assert get_spatial_dimension_variables(test_datatree, variables) == {'/x', '/y'}
 
 
@@ -447,7 +447,7 @@ def test_get_spatial_dimension_variables_no_matches(sample_netcdf4_file_test02) 
     with xr.open_datatree(
         sample_netcdf4_file_test02, decode_times=False
     ) as test_datatree:
-        variables = {'/am_pm'}
+        variables = {'/variable_two'}
         assert get_spatial_dimension_variables(test_datatree, variables) == set()
 
 
@@ -474,7 +474,7 @@ def test_get_grid_start_index_missing_configuration(sample_netcdf4_file_test02) 
         sample_netcdf4_file_test02, decode_times=False
     ) as test_datatree:
         with pytest.raises(MissingStartIndexConfiguration):
-            get_grid_start_index(test_datatree, test_datatree['am_pm'])
+            get_grid_start_index(test_datatree, test_datatree['variable_two'])
 
 
 def test_get_start_index_from_row_col_variable(sample_netcdf4_file_test02) -> None:
@@ -527,7 +527,7 @@ def test_get_spatial_dimension_type_invalid_standard_name(
         sample_netcdf4_file_test02, decode_times=False
     ) as test_datatree:
         with pytest.raises(InvalidDimensionAttribute):
-            get_spatial_dimension_type(test_datatree['z'])
+            get_spatial_dimension_type(test_datatree['variable_one'])
 
 
 def test_get_spatial_dimension_type_missing_standard_name(
@@ -538,7 +538,7 @@ def test_get_spatial_dimension_type_missing_standard_name(
         sample_netcdf4_file_test02, decode_times=False
     ) as test_datatree:
         with pytest.raises(MissingDimensionAttribute):
-            get_spatial_dimension_type(test_datatree['am_pm'])
+            get_spatial_dimension_type(test_datatree['variable_two'])
 
 
 def test_get_geotransform_config(
@@ -563,7 +563,9 @@ def test_get_geotransform_config_missing_grid_mapping_reference(
         sample_netcdf4_file_test02, decode_times=False
     ) as test_datatree:
         with pytest.raises(MissingDimensionAttribute):
-            get_geotransform_config(test_datatree['am_pm'], sample_varinfo_test02)
+            get_geotransform_config(
+                test_datatree['variable_two'], sample_varinfo_test02
+            )
 
 
 def test_get_geotransform_config_invalid_grid_mapping_reference(
@@ -583,4 +585,6 @@ def test_get_geotransform_config_missing_master_geotransform(
         sample_netcdf4_file_test02, decode_times=False
     ) as test_datatree:
         with pytest.raises(MissingDimensionAttribute):
-            get_geotransform_config(test_datatree['z'], sample_varinfo_test02)
+            get_geotransform_config(
+                test_datatree['variable_one'], sample_varinfo_test02
+            )

--- a/tests/unit/test_annotate.py
+++ b/tests/unit/test_annotate.py
@@ -196,6 +196,7 @@ def test_annotate_granule(
     expected_output_netcdf4_file,
     temp_output_file_path,
     varinfo_config_file,
+    mocker,
 ):
     """Confirm that a granule has all metadata updated as expected.
 
@@ -204,6 +205,11 @@ def test_annotate_granule(
     attributes are either added, updated or deleted.
 
     """
+    get_spatial_dimension_variables_mock = mocker.patch(
+        'metadata_annotator.annotate.get_spatial_dimension_variables'
+    )
+    get_spatial_dimension_variables_mock.return_value = set()
+
     annotate_granule(
         sample_netcdf4_file, temp_output_file_path, varinfo_config_file, 'TEST01'
     )

--- a/tests/unit/test_annotate.py
+++ b/tests/unit/test_annotate.py
@@ -30,6 +30,7 @@ from metadata_annotator.annotate import (
 from metadata_annotator.exceptions import (
     InvalidDimensionAttribute,
     InvalidGridMappingReference,
+    InvalidSubsetIndexShape,
     MissingDimensionAttribute,
     MissingStartIndexConfiguration,
     MissingSubsetIndexReference,
@@ -482,6 +483,17 @@ def test_get_start_index_from_row_col_variable_missing_reference(
     ) as test_datatree:
         with pytest.raises(MissingSubsetIndexReference):
             get_start_index_from_row_col_variable(test_datatree, 'missing_variable')
+
+
+def test_get_start_index_from_row_col_variable_invalid_index_shape(
+    sample_netcdf4_file_test02,
+) -> None:
+    """Ensure the expected exception is raised when index variable shape is invalid."""
+    with xr.open_datatree(
+        sample_netcdf4_file_test02, decode_times=False
+    ) as test_datatree:
+        with pytest.raises(InvalidSubsetIndexShape):
+            get_start_index_from_row_col_variable(test_datatree, 'x')
 
 
 def test_get_spatial_dimension_type(sample_netcdf4_file_test02) -> None:

--- a/tests/unit/test_annotate.py
+++ b/tests/unit/test_annotate.py
@@ -13,7 +13,7 @@ from metadata_annotator.annotate import (
     get_matching_groups_and_variables,
     is_exact_path,
     update_dimension_names,
-    update_dimension_variables,
+    update_dimension_variable,
     update_group_and_variable_attributes,
     update_history_metadata,
     update_metadata_attributes,
@@ -314,8 +314,8 @@ def test_get_dimension_variables() -> set[str]:
         )
 
 
-def test_update_dimension_variables() -> None:
-    """Ensure attributes of dimension variables are updated as expected."""
+def test_update_dimension_variable() -> None:
+    """Ensure attributes of a dimension variable are updated as expected."""
     with xr.open_datatree('tests/data/SC_SPL3FTP_spatially_subsetted.nc4') as datatree:
         granule_varinfo = VarInfoFromNetCDF4(
             'tests/data/SC_SPL3FTP_spatially_subsetted.nc4',
@@ -327,7 +327,7 @@ def test_update_dimension_variables() -> None:
         renamed_da = da.rename({'dim0': 'am_pm', 'dim1': 'y', 'dim2': 'x'})
         datatree['/Freeze_Thaw_Retrieval_Data_Global/surface_flag'] = renamed_da
 
-        update_dimension_variables(
+        update_dimension_variable(
             datatree, '/Freeze_Thaw_Retrieval_Data_Global/y', granule_varinfo
         )
         # Ensure that the attributes are updated.

--- a/tests/unit/test_annotate.py
+++ b/tests/unit/test_annotate.py
@@ -419,6 +419,20 @@ def test_update_spatial_dimension_values(
         assert np.allclose(test_datatree['y'], expected_y_result)
 
 
+def test_update_spatial_dimension_values_missing_dimension(
+    sample_netcdf4_file_test02, sample_varinfo_test02
+) -> None:
+    """Ensure exception is raised if dimension variable is missing."""
+    with xr.open_datatree(
+        sample_netcdf4_file_test02, decode_times=False
+    ) as test_datatree:
+        with pytest.raises(Exception):
+            variables = {'/missing_dimension'}
+            update_spatial_dimension_values(
+                test_datatree, variables, sample_varinfo_test02
+            )
+
+
 def test_get_spatial_dimension_variables(sample_netcdf4_file_test02) -> None:
     """Ensure only spatial variable dimensions are returned."""
     with xr.open_datatree(

--- a/tests/unit/test_geotransform.py
+++ b/tests/unit/test_geotransform.py
@@ -1,0 +1,61 @@
+"""Tests for metadata_annotator.geotransform.py."""
+
+import numpy as np
+import pytest
+
+from metadata_annotator.exceptions import InvalidSpatialDimensionType
+from metadata_annotator.geotransform import (
+    Geotransform,
+    compute_dimension_scale,
+    geotransform_from_config,
+)
+
+
+def test_geotransform():
+    """Test basic geotransformation computations."""
+    gt = Geotransform(-2000.0, 1000.0, 0.0, 0.0, 0.0, -1000.0)
+    x, y = gt.col_row_to_xy(0, 0)
+    assert np.isclose(x, -1500.0)
+    assert np.isclose(y, -500.0)
+    x2, y2 = gt.col_row_to_xy(1, 1)
+    assert np.isclose(x2, -500.0)
+    assert np.isclose(y2, -1500.0)
+
+
+def test_geotransform_from_config():
+    """Tests geotransform config info will be parsed for a geotransform."""
+    sample_geotransform_config = [-9000000, 36000, 0, 9000000, 0, -36000]
+    gt = geotransform_from_config(sample_geotransform_config)
+    assert isinstance(gt, Geotransform)
+    assert np.isclose(gt.top_left_x, -9000000.0)
+    assert np.isclose(gt.top_left_y, 9000000.0)
+    assert np.isclose(gt.row_rotation, 0.0)
+    assert np.isclose(gt.column_rotation, 0.0)
+    assert np.isclose(gt.pixel_width, 36000.0)
+    assert np.isclose(gt.pixel_height, -36000.0)
+
+
+def test_compute_dimension_scale_x():
+    """Tests dimension scale is computed correctly."""
+    result = compute_dimension_scale(
+        0, 3, 'x', 'float64', [-9000000, 36000, 0, 9000000, 0, -36000]
+    )
+    expected_result = np.array([-8982000.0, -8946000.0, -8910000.0], dtype=np.float64)
+    assert np.allclose(result, expected_result)
+
+
+def test_compute_dimension_scale_y():
+    """Tests dimension scale is computed correctly."""
+    result = compute_dimension_scale(
+        0, 3, 'y', 'float64', [-9000000, 36000, 0, 9000000, 0, -36000]
+    )
+    expected_result = np.array([8982000.0, 8946000.0, 8910000.0], dtype=np.float64)
+    assert np.allclose(result, expected_result)
+
+
+def test_compute_dimension_scale_raises_invalid_spatial_dimension_type():
+    """Tests dimension scale is computed correctly."""
+    with pytest.raises(InvalidSpatialDimensionType):
+        compute_dimension_scale(
+            0, 3, 'am_pm', 'float64', [-9000000, 36000, 0, 9000000, 0, -36000]
+        )


### PR DESCRIPTION
## Description

This PR adds functionality to create missing dimension scales using the `master_geotransform` attribute defined in earthdata_varinfo_config.json. To select the grid start index/grid offset, a solution was implemented to use the associated row/col index variable (i.e., EASE_row_index_1km). This approach is currently only intended to be used for SPL2SMAP_S. DAS-2356 will implement an alternative method for determining the start index, which is expected to be used in most cases.

## Jira Issue ID
[DAS-2338](https://bugs.earthdata.nasa.gov/browse/DAS-2338)

## Local Test Steps

1. Clone the DAS-2338 branch: `git clone -b DAS-2338 https://github.com/nasa/harmony-metadata-annotator.git`
2. `cd harmony-metadata-annotator`
3. Build the service and test images and run the unit tests. Verify all tests pass.
```shell
./bin/build-image && ./bin/build-test && ./bin/run-test
``` 
5. Create conda env, activate it, and install dependencies
```shell
conda create -n metadata-annotator python=3.11
conda activate metadata-annotator
pip install -r requirements.txt 
``` 
7. Run metadata-annotator locally with the `run_local_metadata_annotator.py` script below. 
- download the input granule from the DAS-2338 ticket and move it to the root directory of the repository.
- update the config_file path

```python
"""Test script to test metadata-annotator standalone
"""

from metadata_annotator.annotate import annotate_granule

input_file = 'SC_SPL2SMAP_S_subsetted.nc4'  
output_file_path = 'SC_SPL2SMAP_S_subsetted_annotated.nc4'
short_name = 'SPL2SMAP_S'
config_file = '/Users/jschul10/repos/harmony-metadata-annotator/metadata_annotator/earthdata_varinfo_config.json'

annotate_granule(input_file, output_file_path, config_file, short_name)

``` 

`(metadata-annotator)% python run_local_metadata_annotator.py`

8. Verify the dimension scales were generated correctly in the output file by inspecting `Soil_Moisture_Retrieval_Data_1km/x`, `Soil_Moisture_Retrieval_Data_1km/y`, `Soil_Moisture_Retrieval_Data_3km/x`, `Soil_Moisture_Retrieval_Data_3km/y`
- See the spl2smap_s_output_analysis.pdf attachment on the DAS-2338 ticket for how I verified the dimension scales. 

## PR Acceptance Checklist

* [x] Jira ticket acceptance criteria met.
* [x] `CHANGELOG.md` updated to include high level summary of PR changes.
* [ ] `docker/service_version.txt` updated if publishing a release.
* [x] Tests added/updated and passing.
* [ ] Documentation updated (if needed).
