### PR TITLE
DAS-2298: Update CHANGELOG for 0.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v1.0.0] - 2025-03-28
+## [v0.0.1] - 2025-03-28
+
+### Added
 
 - This is the first formal release of the Harmony Metadata Annotator as
   as Docker image available through the GitHub Container Registry.
 - Service functionality: Ability to create, update, delete metadata attributes
   for a variable as specified via an `earthdata-varinfo` configuration file.
-
-## [v0.0.1] - 2025-02-20
-
-### Added
-
 - Initial repository setup with utility scripts and Dockerfiles.
 
-[v1.0.0]: https://github.com/nasa/harmony-metadata-annotator/releases/tag/1.0.0
 [v0.0.1]: https://github.com/nasa/harmony-metadata-annotator/releases/tag/0.0.1


### PR DESCRIPTION
## Description

The current service_version is 0.0.1, but the CHANGELOG has an entry for a 1.0.0 release. This PR updates the CHANGELOG to move the changes list under the 1.0.0 entry to the 0.0.1 entry. 

A manual trigger of the workflow to publish the docker image and overwrite the existing 0.0.1 release will follow the PR.

## Jira Issue ID
[DAS-2298](https://bugs.earthdata.nasa.gov/browse/DAS-2298)

## Local Test Steps
N/A

## PR Acceptance Checklist

* [ ] Jira ticket acceptance criteria met.
* [ ] `CHANGELOG.md` updated to include high level summary of PR changes.
* [ ] `docker/service_version.txt` updated if publishing a release.
* [ ] Tests added/updated and passing.
* [ ] Documentation updated (if needed).
