### PR TITLE
DAS-2363: Fix changelog v1.1.0 release link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for a variable as specified via an `earthdata-varinfo` configuration file.
 - Initial repository setup with utility scripts and Dockerfiles.
 
-[v1.0.5]: https://github.com/nasa/harmony-metadata-annotator/releases/tag/1.0.5
+[v1.1.0]: https://github.com/nasa/harmony-metadata-annotator/releases/tag/1.1.0
 [v1.0.4]: https://github.com/nasa/harmony-metadata-annotator/releases/tag/1.0.4
 [v1.0.3]: https://github.com/nasa/harmony-metadata-annotator/releases/tag/1.0.3
 [v1.0.2]: https://github.com/nasa/harmony-metadata-annotator/releases/tag/1.0.2


### PR DESCRIPTION
## Description

There was an error in the CHANGELOG release link entry from the previous [PR](https://github.com/nasa/harmony-metadata-annotator/pull/20). This update corrects it.

## Jira Issue ID
[DAS-2363](https://bugs.earthdata.nasa.gov/browse/DAS-2363)

## Local Test Steps
N/A

## PR Acceptance Checklist

* [N/A] Jira ticket acceptance criteria met.
* [N/A] `CHANGELOG.md` updated to include high level summary of PR changes.
* [N/A] `docker/service_version.txt` updated if publishing a release.
* [N/A] Tests added/updated and passing.
* [N/A] Documentation updated (if needed).
