### PR TITLE
DAS-2418-fix-changelog-link: Add missing link to 1.5.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for a variable as specified via an `earthdata-varinfo` configuration file.
 - Initial repository setup with utility scripts and Dockerfiles.
 
+[v1.5.0]: https://github.com/nasa/harmony-metadata-annotator/releases/tag/1.5.0
 [v1.4.0]: https://github.com/nasa/harmony-metadata-annotator/releases/tag/1.4.0
 [v1.3.0]: https://github.com/nasa/harmony-metadata-annotator/releases/tag/1.3.0
 [v1.2.0]: https://github.com/nasa/harmony-metadata-annotator/releases/tag/1.2.0


### PR DESCRIPTION
## Description

The previous PR [#33](https://github.com/nasa/harmony-metadata-annotator/pull/33) was missing the link to the 1.5.0 release in the changelog. This PR adds it.

## Jira Issue ID
[DAS-2418](https://bugs.earthdata.nasa.gov/browse/DAS-2418)

## Local Test Steps
N/A

## PR Acceptance Checklist

* [N/A] Jira ticket acceptance criteria met.
* [N/A] `CHANGELOG.md` updated to include high level summary of PR changes.
* [N/A] `docker/service_version.txt` updated if publishing a release.
* [N/A] Fix version [harmony-metadata-annotator-X.Y.Z] added to Jira ticket if publishing a release.
* [N/A] Tests added/updated and passing.
* [N/A] Documentation updated (if needed).
